### PR TITLE
adding readOnly entry for Property initializer

### DIFF
--- a/index.html
+++ b/index.html
@@ -472,7 +472,7 @@
       object contentType;
       SemanticType[] semanticTypes;
       any value;
-      boolean readOnly = false;
+      boolean writable = false;
     };
 
     dictionary ThingEvent {

--- a/index.html
+++ b/index.html
@@ -472,6 +472,7 @@
       object contentType;
       SemanticType[] semanticTypes;
       any value;
+      boolean readOnly = false;
     };
 
     dictionary ThingEvent {


### PR DESCRIPTION
addressing #18 
defaulting to writeable.
using default false value according to [WebIDL recommendation](https://www.w3.org/TR/WebIDL-1/#dfn-dictionary-member-default-value), therefore readOnly instead of writeable.


