### PR TITLE
FPWD edits

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
       The <a>Web of Things</a> (WoT) provides layered interoperability between <a>Things</a> by using the <a>WoT Interface</a>s.
     </p>
     <p>
-      This specification describes a programming interface representing the <a>WoT Interface</a> that allows scripts run on a <a>Thing</a> to discover and consume (retrieve) other <a>Thing</a>s and to expose <a>Things</a> characterized by properties, actions and events.
+      This specification describes a programming interface representing the <a>WoT Interface</a> that allows scripts run on a <a>Thing</a> to discover and consume (retrieve) other <a>Thing</a>s and to expose <a>Things</a> characterized by properties, <a>Actions</a> and <a>Events</a>.
     </p>
     <p>
       Scripting is an optional "convenience" building block in WoT and it is typically used in gateways that are able to run a <a>WoT Runtime</a> and <a href="https://w3c.github.io/wot-scripting-api/script-manager/")>script management</a>, providing a convenient way to extend WoT support to new types of endpoints and implement WoT applications like <a href="https://w3c.github.io/wot-scripting-api/script-manager/")>Thing Directory</a>.
@@ -123,10 +123,10 @@
       The Web of Things is made of entities (<a>Thing</a>s) that can describe their capabilities in a machine-interpretable format, the <a>Thing Description</a> (TD) and expose these capabilities through the <a>WoT Interface</a>. Support for scripting is optional for WoT devices.
     </p>
     <p>
-      By <a>consuming a TD</a>, a client <a>Thing</a> creates a runtime resource model that allows accessing the properties, actions and events exposed by the server <a>Thing</a>.
+      By <a>consuming a TD</a>, a client <a>Thing</a> creates a runtime resource model that allows accessing the properties, <a>Actions</a> and <a>Events</a> exposed by the server <a>Thing</a>.
     </p>
     <p>
-      Exposing a <a>Thing</a> requires defining a <a>Thing Description</a> and instantiating a software stack needed to serve requests for accessing the exposed properties, actions and events. This specification describes how to expose and consume <a>Thing</a>s by a script.
+      Exposing a <a>Thing</a> requires defining a <a>Thing Description</a> and instantiating a software stack needed to serve requests for accessing the exposed properties, <a>Actions</a> and <a>Events</a>. This specification describes how to expose and consume <a>Thing</a>s by a script.
     </p>
     <p class="note">
       Typically scripts are meant to be used on devices able to provide resources (with a <a>WoT interface</a>) for managing (installing, updating, running) scripts, such as bridges or gateways that expose and control simpler devices as WoT <a>Thing</a>s.
@@ -148,21 +148,23 @@
       <li>Fetch and <a>consume a TD</a> of a remote <a>Thing</a>.</li>
       <li>On a consumed <a>Thing</a>,
         <ul>
-          <li>Get the value of a property or set of properties.</li>
-          <li>Set the value of a property or a set of properties.</li>
-          <li>Invoke an action.</li>
+          <li>Get the value of a <a>Property</a> or set of properties.</li>
+          <li>Set the value of a <a>Property</a> or a set of properties.</li>
+          <li>Invoke an <a>Action</a>.</li>
           <li>
-            Observe events.
+            Observe <a>Events</a>.
             <ul>
-              <li>Add a listener to an event.</li>
-              <li>Remove a listener from an event.</li>
+              <li>Add a listener to an <a>Event</a>.</li>
+              <li>Remove a listener from an <a>Event</a>.</li>
               <li>Remove all listeners.</li>
             </ul>
-            Default events are the following:
+            Default <a>Events</a> are the following:
             <ul>
-              <li>A property has changed.</li>
-              <li>An action has been invoked.</li>
-              <li><a>Thing Description</a> has changed, i.e. properties, events or actions have been defined, removed, or the definition has changed.</li>
+              <li>A <a>Property</a> has changed.</li>
+              <li>An <a>Action</a> has been invoked.</li>
+              <li>
+                <a>Thing Description</a> has changed, i.e. <a>Properties</a>, <a>Events</a> or <a>Actions</a> have been defined, removed, or the definition has changed.
+              </li>
             </ul>
           </li>
         </ul>
@@ -172,20 +174,24 @@
       <li>Programmatically create and expose a local <a>Thing</a>. This may include the following use cases:
         <ul>
           <li>Create a local <a>Thing</a>.</li>
-          <li>Add a property definition to the <a>Thing</a>.</li>
-          <li>Add an event definition to the <a>Thing</a>.</li>
-          <li>Add an action definition to the <a>Thing</a>.</li>
-          <li>Attach semantic information to an action</li>
-          <li>Attach semantic information to a property</li>
-          <li>Attach semantic information to an event</li>
-          <li>Emit an event, i.e. notify all listeners subscribed to that event.</li>
+          <li>Add a <a>Property</a> definition to the <a>Thing</a>.</li>
+          <li>Add an <a>Event</a> definition to the <a>Thing</a>.</li>
+          <li>Add an <a>Action</a> definition to the <a>Thing</a>.</li>
+          <li>Attach semantic information to an <a>Action</a></li>
+          <li>Attach semantic information to a <a>Property</a></li>
+          <li>Attach semantic information to an <a>Event</a></li>
+          <li>
+            Emit an <a>Event</a>, i.e. notify all listeners subscribed to that <a>Event</a>.
+          </li>
           <li>Register handlers for external requests:
             <ul>
-              <li>to retrieve a property value;</li>
-              <li>to update a property value;</li>
-              <li>to run an action: take the parameters from the request, execute the defined action, and return the result;</li>
-              <li>to add a listener to an event;</li>
-              <li>to remove an event listener.</li>
+              <li>to retrieve a <a>Property</a> value;</li>
+              <li>to update a <a>Property</a> value;</li>
+              <li>
+                to run an <a>Action</a>: take the parameters from the request, execute the defined action, and return the result;
+              </li>
+              <li>to add a listener to an <a>Event</a>;</li>
+              <li>to remove an <a>Event</a> listener.</li>
               <li>to fetch the <a>Thing Description</a>;</li>
             </ul>
           </li>
@@ -200,9 +206,15 @@
       The following use cases are being considered for next versions:
     </p>
     <ul>
-      <li>Add, remove and update the definition of a property on a Thing that runs in the same the WoT Runtime.</li>
-      <li>Add, remove and update the definition of an action on a Thing that runs in the same the WoT Runtime.</li>
-      <li>Add, remove and update the definition of an event on a Thing that runs in the same the WoT Runtime.</li>
+      <li>
+        Add, remove and update the definition of a <a>Property</a> on a Thing that runs in the same the WoT Runtime.
+      </li>
+      <li>
+        Add, remove and update the definition of an <a>Action</a> on a Thing that runs in the same the WoT Runtime.
+      </li>
+      <li>
+        Add, remove and update the definition of an <a>Event</a> on a Thing that runs in the same the WoT Runtime.
+      </li>
     </ul>
   </section>
 
@@ -362,7 +374,7 @@
   <section data-dfn-for="ConsumedThing">
     <h2>The <dfn>ConsumedThing</dfn> interface</h2>
     <p>
-      The <a>ConsumedThing</a> interface is a client API for sending requests to servers in order to retrieve or update properties, invoke actions, and observe properties, actions and events.
+      The <a>ConsumedThing</a> interface is a client API for sending requests to servers in order to retrieve or update properties, invoke <a>Actions</a>, and observe properties, <a>Actions</a> and <a>Events</a>.
     </p>
     <pre class="idl">
       interface ConsumedThing {
@@ -394,43 +406,43 @@
 
     <section> <h3>The <dfn>invokeAction()</dfn> method</h3>
       <p>
-        Takes the action name as the <var>name</var> argument and the list of parameters, then requests from the underlying platform and the <a>Protocol Bindings</a> to invoke the action on the remote <a>Thing</a> and return the result. Returns a <code><a>Promise</a></code> that resolves with the return value or rejects with an <a>Error</a>.
+        Takes the <a>Action</a> name from the <var>name</var> argument and the list of parameters, then requests from the underlying platform and the <a>Protocol Bindings</a> to invoke the <a>Action</a> on the remote <a>Thing</a> and return the result. Returns a <code><a>Promise</a></code> that resolves with the return value or rejects with an <a>Error</a>.
       </p>
     </section>
 
     <section> <h3>The <dfn>setProperty()</dfn> method</h3>
       <p>
-        Takes the property name as the <var>name</var> argument and the new value as the <var>value</var> argument, then requests from the underlying platform and the <a>Protocol Bindings</a> to update the property on the remote <a>Thing</a> and return the result. Returns a <code><a>Promise</a></code> that resolves on success or rejects with an <a>Error</a>.
+        Takes the <a>Property</a> name as the <var>name</var> argument and the new value as the <var>value</var> argument, then requests from the underlying platform and the <a>Protocol Bindings</a> to update the <a>Property</a> on the remote <a>Thing</a> and return the result. Returns a <code><a>Promise</a></code> that resolves on success or rejects with an <a>Error</a>.
       </p>
     </section>
 
     <section> <h3>The <dfn>getProperty()</dfn> method</h3>
       <p>
-        Takes the property name as the <var>name</var> argument, then requests from the underlying platform  and the <a>Protocol Bindings</a> to retrieve the property on the remote <a>Thing</a> and return the result. Returns a <code><a>Promise</a></code> that resolves with the property value or rejects with an <a>Error</a>.
+        Takes the <a>Property</a> name as the <var>name</var> argument, then requests from the underlying platform  and the <a>Protocol Bindings</a> to retrieve the <a>Property</a> on the remote <a>Thing</a> and return the result. Returns a <code><a>Promise</a></code> that resolves with the <a>Property</a> value or rejects with an <a>Error</a>.
       </p>
     </section>
 
     <section> <h3>The <dfn>addListener()</dfn> method</h3>
       <p>
-        Adds the listener provided in the argument <var>listener</var> to the event name provided in the argument <var>eventName</var>.
+        Adds the listener provided in the argument <var>listener</var> to the <a>Event</a> name provided in the argument <var>eventName</var>.
       </p>
     </section>
 
     <section> <h3>The <dfn>removeListener()</dfn> method</h3>
       <p>
-        Removes a listener from the event identified by the provided <var>eventName</var> and <var>listener</var> argument.
+        Removes a listener from the <a>Event</a> identified by the provided <var>eventName</var> and <var>listener</var> argument.
       </p>
     </section>
 
     <section> <h3>The <dfn>removeAllListeners()</dfn> method</h3>
       <p>
-        Removes all listeners for the event provided by the <var>eventName</var> optional argument, or if that was not provided, then removes all listeners from all events.
+        Removes all listeners for the <a>Event</a> provided by the <var>eventName</var> optional argument, or if that was not provided, then removes all listeners from all <a>Events</a>.
       </p>
     </section>
 
     <section> <h3>The <dfn>observe()</dfn> method</h3>
       <p>
-        Returns an <a>Observable</a> for the property, event or action specified in the <var>name</var> argument, allowing subscribing and unsubscribing to notifications. The <var>requestType</var> specifies whether a property, an event or an action is observed.
+        Returns an <a>Observable</a> for the <a>Property</a>, <a>Event</a> or <a>Action</a> specified in the <var>name</var> argument, allowing subscribing and unsubscribing to notifications. The <var>requestType</var> specifies whether a <a>Property</a>, an <a>Event</a> or an <a>Action</a> is observed.
       </p>
       <p class="ednote">
         The <code>observe()</code> method could replace <code>addListener()</code> and <code>removeListener()</code>, though they could be kept for convenience.
@@ -440,13 +452,13 @@
     <section data-dfn-for="ThingEventListener">
       <h2>The <dfn>ThingEventListener</dfn> callback</h2>
       <p>
-        A function called with an <a>Event</a> object when an event is emitted.
+        A function called with an <a data-lt="DOM-Level-2-Events">Event</a> object when an event is emitted.
       </p>
     </section>
 
     <section> <h2>Events</h2>
       <p>
-        Clients can subscribe to the events defined in <a href="#events-supported-by-exposedthing">ExposedThing events</a>. The event types are described in this section.
+        Clients can subscribe to the <a>Events</a> defined in <a href="#events-supported-by-exposedthing">ExposedThing events</a>. The event types are described in this section.
       </p>
 
       <section data-dfn-for="PropertyChangeEvent">
@@ -458,7 +470,7 @@
           };
         </pre>
         <p>The <var>name</var> attribute of the event is <code>"propertychange"</code>.</p>
-        <p>The <dfn>value</dfn> attribute represents the new value of the property.</p>
+        <p>The <dfn>value</dfn> attribute represents the new value of the <a>Property</a>.</p>
       </section>
 
       <section data-dfn-for="ActionInvocationEvent">
@@ -470,7 +482,7 @@
           };
         </pre>
         <p>
-            The <dfn>data</dfn> attribute represents the notification data from the action invocation.
+            The <dfn>data</dfn> attribute represents the notification data from the <a>Action</a> invocation.
         </p>
         <section data-dfn-for="ActionInvocationEventInit">
           <h2>The <dfn>ActionInvocationEventInit</dfn> dictionary</h2>
@@ -484,10 +496,10 @@
             Action parameters could be also included, but it's debateble because privacy reasons.
           </p>
           <p>
-            The <dfn>actionName</dfn> attribute represents the name of the action that has been invoked.
+            The <dfn>actionName</dfn> attribute represents the name of the <a>Action</a> that has been invoked.
           </p>
           <p>
-            The <dfn>returnValue</dfn> attribute represents the return value of the action.
+            The <dfn>returnValue</dfn> attribute represents the return value of the <a>Action</a>.
           </p>
         </section>
       </section>
@@ -516,13 +528,13 @@
           </pre>
           <ul>
             <li>
-              The <dfn>type</dfn> attribute represents the change type, whether has it been applied on properties, actions or events.
+              The <dfn>type</dfn> attribute represents the change type, whether has it been applied on properties, <a>Actions</a> or <a>Events</a>.
             </li>
             <li>
              The <dfn>method</dfn> attribute tells what operation has been applied, addition, removal or change.
             </li>
             <li>
-              The <dfn>name</dfn> attribute represents the name of the property, action or event that has changed.
+              The <dfn>name</dfn> attribute represents the name of the <a>Property</a>, <a>Action</a> or event that has changed.
             </li>
             <li>
               The <dfn>description</dfn> attribute is defined for the addition and change methods, and represents the new description.
@@ -537,9 +549,9 @@
               enum TDChangeMethod { "add", "remove", "change" };
             </pre>
             <ul>
-              <li>The <dfn>add</dfn> value denotes addition of a property, action or event.</li>
-              <li>The <dfn>remove</dfn> value denotes removal of a property, action or event.</li>
-              <li>The <dfn>change</dfn> value denotes a change applied on a property, action or event.</li>
+              <li>The <dfn>add</dfn> value denotes addition of a <a>Property</a>, <a>Action</a> or event.</li>
+              <li>The <dfn>remove</dfn> value denotes removal of a <a>Property</a>, <a>Action</a> or event.</li>
+              <li>The <dfn>change</dfn> value denotes a change applied on a <a>Property</a>, <a>Action</a> or event.</li>
             </ul>
           </section>
           <section data-dfn-for="TDChangeType">
@@ -549,7 +561,7 @@
               typedef (ThingPropertyInit or ThingActionInit or ThingEventInit) TDChangeData;
             </pre>
             <ul>
-              <li>The <dfn>property</dfn> value tells the operation was applied on a property definition.</li>
+              <li>The <dfn>property</dfn> value tells the operation was applied on a <a>Property</a> definition.</li>
               <li>The <dfn>action</dfn> value tells the operation was applied on a action definition.</li>
               <li>The <dfn>event</dfn> value tells the operation was applied on an event definition.</li>
             </ul>
@@ -589,7 +601,7 @@
   <section data-dfn-for="ExposedThing">
     <h2>The <dfn>ExposedThing</dfn> interface</h2>
     <p>
-      The <a>ExposedThing</a> interface is the server API that allows defining request handlers, properties, actions, and events to a <a>Thing</a>.
+      The <a>ExposedThing</a> interface is the server API that allows defining request handlers, properties, <a>Actions</a>, and <a>Events</a> to a <a>Thing</a>.
     </p>
     <pre class="idl">
       typedef USVString ThingDescription;
@@ -642,7 +654,7 @@
         };
       </pre>
       <p>
-        Represents an incoming request the <a>ExposedThing</a> is supposed to handle, for instance retrieving and updating properties, invoking actions and observing events (WoT interactions).
+        Represents an incoming request the <a>ExposedThing</a> is supposed to handle, for instance retrieving and updating properties, invoking <a>Actions</a> and observing <a>Events</a> (WoT interactions).
         <ul>
           <li>
             The <dfn>type</dfn> attribute represents the type of the request as defined in <a>RequestType</a>.
@@ -651,13 +663,13 @@
             The <dfn>from</dfn> attribute represents the address of the client device issuing the request. The type of the address (URL, UUID or other) is defined by the <a>Thing Description</a>.
           </li>
           <li>
-            The <dfn>name</dfn> attribute represents the name of the property to be retrieved or updated, or the name of the invoked action, or the event name to be observed.
+            The <dfn>name</dfn> attribute represents the name of the <a>Property</a> to be retrieved or updated, or the name of the invoked <a>Action</a>, or the event name to be observed.
           </li>
           <li>
             The <dfn>options</dfn> attribute represents the options relevant to the request (e.g. the format or measurement units for the returned value) as key-value pairs. The exact format is specified by the <a>Thing Description</a>.
           </li>
           <li>
-            The <dfn>data</dfn> attribute represents the value of the property, or the input data (arguments) of an action. It is not used for retrieve requests and event requests, only for property update and action invocation requests.
+            The <dfn>data</dfn> attribute represents the value of the <a>Property</a>, or the input data (arguments) of an <a>Action</a>. It is not used for retrieve requests and event requests, only for <a>Property</a> update and <a>Action</a> invocation requests.
           </li>
         </ul>
       </p>
@@ -667,11 +679,11 @@
           enum RequestType { "property", "action", "event", "td" };
         </pre>
         <ul>
-          <li>The value "<dfn>property</dfn>" represents requests to retrieve or update a property.</li>
-          <li>The value "<dfn>action</dfn>" represents requests to invoke an action.</li>
+          <li>The value "<dfn>property</dfn>" represents requests to retrieve or update a <a>Property</a>.</li>
+          <li>The value "<dfn>action</dfn>" represents requests to invoke an <a>Action</a>.</li>
           <li>The value "<dfn>event</dfn>" represents requests to emit an event.</li>
           <li>
-            The value "<dfn>td</dfn>" represents requests to change the <a>Thing Description</a>, i.e. to add, remove or modify properties, actions or events.
+            The value "<dfn>td</dfn>" represents requests to change the <a>Thing Description</a>, i.e. to add, remove or modify properties, <a>Actions</a> or <a>Events</a>.
             <p class="ednote">
               This functionality is here for the sake of completeness for future versions of the API. Currently there is no corresponding functionality at the <a>ConsumedThing</a> level and it is not guaranteed that a Thing Description could be remotely changed by scripting.
             </p>
@@ -699,7 +711,7 @@
 
     <section> <h3>The <dfn>addProperty()</dfn> method</h3>
       <p>
-        Adds a property defined by the argument and updates the <a>Thing Description</a>.
+        Adds a <a>Property</a> defined by the argument and updates the <a>Thing Description</a>.
       </p>
       <section data-dfn-for="ThingPropertyInit">
         <h4>The <dfn>ThingPropertyInit</dfn> dictionary</h4>
@@ -715,24 +727,24 @@
           };
         </pre>
         <p>
-          Represents the <a>Thing</a> property description.
+          Represents the <a>Thing</a> <a>Property</a> description.
           <ul>
-            <li>The <dfn>name</dfn> attribute represents the name of the property.</li>
-            <li>The <dfn>value</dfn> attribute represents the value of the property.</li>
+            <li>The <dfn>name</dfn> attribute represents the name of the <a>Property</a>.</li>
+            <li>The <dfn>value</dfn> attribute represents the value of the <a>Property</a>.</li>
             <li>
-              The <dfn>configurable</dfn> attribute defines whether the property can be deleted from the object and whether its properties can be changed. The default value is <code>false</code>.
+              The <dfn>configurable</dfn> attribute defines whether the <a>Property</a> can be deleted from the object and whether its properties can be changed. The default value is <code>false</code>.
             </li>
             <li>
-              The <dfn>enumerable</dfn> attribute defines whether the property can be listed and iterated. The default value is <code>true</code>.
+              The <dfn>enumerable</dfn> attribute defines whether the <a>Property</a> can be listed and iterated. The default value is <code>true</code>.
             </li>
             <li>
-              The <dfn>writable</dfn> attribute defines whether the property can be updated. The default value is <code>true</code>.
+              The <dfn>writable</dfn> attribute defines whether the <a>Property</a> can be updated. The default value is <code>true</code>.
             </li>
             <li>
-              The <dfn>semanticTypes</dfn> attribute represents a list of semantic type annotations (e.g. labels, classifications etc) relevant to the property, represented as <a>SemanticType</a> dictionaries.
+              The <dfn>semanticTypes</dfn> attribute represents a list of semantic type annotations (e.g. labels, classifications etc) relevant to the <a>Property</a>, represented as <a>SemanticType</a> dictionaries.
             </li>
             <li>
-              The <dfn>description</dfn> attribute represents the property description to be added to the <a>Thing Description</a>.
+              The <dfn>description</dfn> attribute represents the <a>Property</a> description to be added to the <a>Thing Description</a>.
             </li>
           </ul>
         </p>
@@ -761,13 +773,13 @@
 
     <section> <h3>The <dfn>removeProperty()</dfn> method</h3>
       <p>
-        Removes the property specified by the <code>name</code> argument, updates the <a>Thing Description</a> and returns the object.
+        Removes the <a>Property</a> specified by the <code>name</code> argument, updates the <a>Thing Description</a> and returns the object.
       </p>
     </section>
 
     <section> <h3>The <dfn>addAction()</dfn> method</h3>
       <p>
-        Adds an action to the <a>Thing</a> object as defined by the <code>action</code> argument of type <a>ThingActionInit</a> and updates the <a>Thing Description</a>.
+        Adds an <a>Action</a> to the <a>Thing</a> object as defined by the <code>action</code> argument of type <a>ThingActionInit</a> and updates the <a>Thing Description</a>.
       </p>
       <section data-dfn-for="ThingActionInit">
         <h4>The <dfn>ThingActionInit</dfn> dictionary</h4>
@@ -783,12 +795,12 @@
       <p>
         The <a>ThingActionInit</a> dictionary describes the arguments and the return value.
         <ul>
-          <li>The <dfn>name</dfn> attribute provides the action name.</li>
-          <li>The <dfn>action</dfn> attribute provides a function that defines the action.</li>
+          <li>The <dfn>name</dfn> attribute provides the <a>Action</a> name.</li>
+          <li>The <dfn>action</dfn> attribute provides a function that defines the <a>Action</a>.</li>
           <li>The <dfn>inputDataDescription</dfn> attribute provides the description of the input arguments.</li>
           <li>The <dfn>outputDataDescription</dfn> attribute provides the description of the returned data.</li>
           <li>
-              The <dfn>semanticTypes</dfn> attribute provides a list of semantic type annotations (e.g. labels, classifications etc) relevant to the action, represented as <a>SemanticType</a> dictionaries.
+              The <dfn>semanticTypes</dfn> attribute provides a list of semantic type annotations (e.g. labels, classifications etc) relevant to the <a>Action</a>, represented as <a>SemanticType</a> dictionaries.
           </li>
         </ul>
       </p>
@@ -797,7 +809,7 @@
 
     <section> <h3>The <dfn>removeAction()</dfn> method</h3>
       <p>
-        Removes the action specified by the <code>name</code> argument, updates the <a>Thing Description</a> and returns the object.
+        Removes the <a>Action</a> specified by the <code>name</code> argument, updates the <a>Thing Description</a> and returns the object.
       </p>
     </section>
 
@@ -830,19 +842,19 @@
 
     <section> <h3>The <dfn>onRetrieveProperty()</dfn> method</h3>
       <p>
-        Registers the handler function for property retrieve requests received for the <a>Thing</a>, as defined by the <code>handler</code> property of type <code><a>RequestHandler</a></code>. The handler will receive an argument <var>request</var> of type <code><a>Request</a></code> where at least <var>request.name</var> is defined and represents the name of the property to be retrieved.
+        Registers the handler function for <a>Property</a> retrieve requests received for the <a>Thing</a>, as defined by the <code>handler</code> property of type <code><a>RequestHandler</a></code>. The handler will receive an argument <var>request</var> of type <code><a>Request</a></code> where at least <var>request.name</var> is defined and represents the name of the <a>Property</a> to be retrieved.
       </p>
     </section>
 
     <section> <h3>The <dfn>onUpdateProperty()</dfn> method</h3>
       <p>
-        Defines the handler function for property update requests received for the <a>Thing</a>, as defined by the <code>handler</code> property of type <code><a>RequestHandler</a></code>. The handler will receive an argument <var>request</var> of type <code><a>Request</a></code> where <var>request.name</var> defines the name of the property to be retrieved and <var>request.data</var> defines the new value of the property.
+        Defines the handler function for <a>Property</a> update requests received for the <a>Thing</a>, as defined by the <code>handler</code> property of type <code><a>RequestHandler</a></code>. The handler will receive an argument <var>request</var> of type <code><a>Request</a></code> where <var>request.name</var> defines the name of the <a>Property</a> to be retrieved and <var>request.data</var> defines the new value of the <a>Property</a>.
       </p>
     </section>
 
     <section> <h3>The <dfn>onInvokeAction()</dfn> method</h3>
       <p>
-        Defines the handler function for action invocation requests received for the <a>Thing</a>, as defined by the <code>handler</code> property of type <code><a>RequestHandler</a></code>.  The handler will receive an argument <var>request</var> of type <code><a>Request</a></code> where <var>request.name</var> defines the name of the action to be invoked and <var>request.data</var> defines the input arguments for the action as defined by the <a>Thing Description</a>.
+        Defines the handler function for <a>Action</a> invocation requests received for the <a>Thing</a>, as defined by the <code>handler</code> property of type <code><a>RequestHandler</a></code>.  The handler will receive an argument <var>request</var> of type <code><a>Request</a></code> where <var>request.name</var> defines the name of the <a>Action</a> to be invoked and <var>request.data</var> defines the input arguments for the <a>Action</a> as defined by the <a>Thing Description</a>.
       </p>
     </section>
 
@@ -851,10 +863,10 @@
         Defines the handler function for observe requests received for the <a>Thing</a>, as defined by the <code>handler</code> property of type <code><a>RequestHandler</a></code>. The handler will receive an argument <var>request</var> of type <code><a>Request</a></code> where
         <ul>
           <li>
-            <var>request.name</var> defines the name of the property or action or event to be observed.
+            <var>request.name</var> defines the name of the <a>Property</a> or <a>Action</a> or event to be observed.
           </li>
           <li>
-            <var>request.options.observeType</var> is of type <a>RequestType</a> and defines whether a property change or action invocation or event emitting is observed, or the changes to the <a>Thing Description </a> are observed.
+            <var>request.options.observeType</var> is of type <a>RequestType</a> and defines whether a <a>Property</a> change or <a>Action</a> invocation or event emitting is observed, or the changes to the <a>Thing Description </a> are observed.
           </li>
           <li>
             <var>request.options.subscribe</var> is <code>true</code> if subscription is turned or kept being turned on, and it is <code>false</code> when subscription is turned off.
@@ -865,13 +877,13 @@
 
     <section> <h3>The <dfn>register()</dfn> method</h3>
       <p>
-        Generates the <a>Thing Description</a> given the properties, actions and events defined for this object. If a <code>directory</code> argument is given, make a request to register the <a>Thing Description</a> with the given WoT repository by invoking its <code>register</code> action.
+        Generates the <a>Thing Description</a> given the properties, <a>Actions</a> and <a>Event</a> defined for this object. If a <code>directory</code> argument is given, make a request to register the <a>Thing Description</a> with the given WoT repository by invoking its <code>register</code> <a>Action</a>.
       </p>
     </section>
 
     <section> <h3>The <dfn>unregister()</dfn> method</h3>
       <p>
-        If a <code>directory</code> argument is given, make a request to unregister the <a>Thing Description</a> with the given WoT repository by invoking its <code>unregister</code> action. Then, and in the case no arguments were provided to this function, stop the <a>Thing</a> and remove the <a>Thing Description</a>.
+        If a <code>directory</code> argument is given, make a request to unregister the <a>Thing Description</a> with the given WoT repository by invoking its <code>unregister</code> <a>Action</a>. Then, and in the case no arguments were provided to this function, stop the <a>Thing</a> and remove the <a>Thing Description</a>.
       </p>
     </section>
 
@@ -1003,10 +1015,10 @@
 
   <section> <h2>Terminology and conventions</h2>
     <p>
-      The generic WoT terminology is defined in [[!WOT-ARCHITECTURE]]: <dfn data-lt="Things">Thing</dfn>, <dfn data-lt="Thing Descriptions">Thing Description</dfn> (in short <dfn>TD</dfn>), <dfn>Web of Things</dfn> (in short <b><i>WoT</i></b>),  <dfn>WoT Interface</dfn>, <dfn>Protocol Bindings</dfn>, <dfn>WoT Runtime</dfn>, <dfn data-lt="consume|consume a TD|consuming a TD">Consuming a Thing Description</dfn>, <dfn>Thing Directory</dfn> etc.
+      The generic WoT terminology is defined in [[!WOT-ARCHITECTURE]]: <dfn data-lt="Things">Thing</dfn>, <dfn data-lt="Thing Descriptions">Thing Description</dfn> (in short <dfn>TD</dfn>), <dfn>Web of Things</dfn> (in short <b><i>WoT</i></b>),  <dfn>WoT Interface</dfn>, <dfn>Protocol Bindings</dfn>, <dfn>WoT Runtime</dfn>, <dfn data-lt="consume|consume a TD|consuming a TD">Consuming a Thing Description</dfn>, <dfn>Thing Directory</dfn>, <dfn data-lt="Properties">Property</dfn>, <dfn data-lt="Actions">Action</dfn>, <dfn data-lt="Events|WoT-Event">Event</dfn> etc.
     </p>
     <p class="note">
-      In this version of the specification, a <a>WoT Runtime</a> is assumed to run scripts that uses this API to define one or more <a>Thing</a>s that share a common event loop. Script deployment methods are out of scope of this version. In future versions, running multiple scripts (as modules) may be possible, and script deployment MAY be implemented using a manager <a>Thing</a> whose actions permit script lifecycle management operations.
+      In this version of the specification, a <a>WoT Runtime</a> is assumed to run scripts that uses this API to define one or more <a>Thing</a>s that share a common event loop. Script deployment methods are out of scope of this version. In future versions, running multiple scripts (as modules) may be possible, and script deployment MAY be implemented using a manager <a>Thing</a> whose <a>Actions</a> permit script lifecycle management operations.
     </p>
     <p>
       <dfn>JSON-LD</dfn> is defined in [[!JSON-LD]] as a JSON document that is augmented with support for Linked Data by providing a <code>@context</code> property with a defining URI .
@@ -1103,7 +1115,7 @@
       <a href="http://heycam.github.io/webidl/#idl-any"><dfn>any</dfn></a> are defined in [[!WEBIDL]].
     </p>
     <p>
-      The term <b><i>event</i></b> and the <dfn>Event</dfn> object are defined in [DOM](https://www.w3.org/TR/DOM-Level-2-Events/events.html) and [Node.js](https://nodejs.org/api/events.html).
+      The term <b><i>event</i></b> and the <b><i>Event</i></b> object are defined in [DOM](https://www.w3.org/TR/DOM-Level-2-Events/events.html) and [Node.js](https://nodejs.org/api/events.html).
     </p>
     <p class="note">
       This specification uses the convention that an event listener will receive an [Event](https://www.w3.org/TR/DOM-Level-2-Events/ecma-script-binding.html) object. This should work both in a browser environment and in a Node.js like environment.

--- a/index.html
+++ b/index.html
@@ -101,7 +101,13 @@
 
   <section id="abstract">
     <p>
-      This specification describes a programming interface to the <a>Web of Things</a> (WoT), that allows scripts run on a <a>Thing</a> to discover and access other <a>Thing</a>s through a <a>Client API</a>, provide resources characterized by properties, actions and events through a <a>Server API</a>, and access locally attached hardware. Scripting is an optional building block in WoT and it is typically used in gateways that are able to run a <a>WoT Runtime</a> and <a href="https://w3c.github.io/wot-scripting-api/script-manager/")>script management</a>, providing a way to extend WoT support to new types of endpoints and implement WoT applications like <a href="https://w3c.github.io/wot-scripting-api/script-manager/")>Things Directory</a>.
+      The <a>Web of Things</a> (WoT) provides layered interoperability between <a>Things</a> by using the <a>WoT Interface</a>s.
+    </p>
+    <p>
+      This specification describes a convenient programming interface representing the <a>WoT Interface</a> that allows scripts run on a <a>Thing</a> to discover and access other <a>Thing</a>s through a <a>Client API</a>, provide resources characterized by properties, actions and events through a <a>Server API</a>, and access locally attached hardware.
+    </p>
+    <p>
+      Scripting is an optional building block in WoT and it is typically used in gateways that are able to run a <a>WoT Runtime</a> and <a href="https://w3c.github.io/wot-scripting-api/script-manager/")>script management</a>, providing a convenient way to extend WoT support to new types of endpoints and implement WoT applications like <a href="https://w3c.github.io/wot-scripting-api/script-manager/")>Things Directory</a>.
     </p>
   </section>
 
@@ -111,153 +117,13 @@
     </p>
   </section>
 
-  <section id="conformance">
-    <p>
-      This document defines conformance criteria that apply to a single product: the <dfn>UA</dfn> (user agent) that implements the interfaces it contains.
-    </p>
-    <p>
-      This specification can be used for implementing the WoT Scripting API in multiple programming languages. The interface definitions are specified in [[!WEBIDL]].
-    </p>
-    <p>
-      The user agent (UA) may be implemented in the browser, or in a separate runtime environment, such as [Node.js](https://nodejs.org/en/) or small embedded runtimes.
-    </p>
-    <p>
-      Implementations that use ECMAScript executed in a browser to implement the APIs defined in this document MUST implement them in a manner consistent with the ECMAScript Bindings defined in the Web IDL specification [[!WEBIDL]].
-    </p>
-    <p>
-      Implementations that use TypeScript or ECMAScript in a runtime to implement the APIs defined in this document MUST implement them in a manner consistent with the TypeScript Bindings defined in the TypeScript specification [[!TYPESCRIPT]].
-    </p>
-    <p>
-      This document serves a general description of the WoT Scripting API. Language and runtime specific issues are discussed in separate extensions of this document.
-    </p>
-  </section>
-
-  <section> <h2>Terminology and conventions</h2>
-    <p>
-      The generic WoT terminology is defined in [[!WOT-ARCHITECTURE]]: <dfn data-lt="Things">Thing</dfn>, <dfn data-lt="Thing Descriptions">Thing Description</dfn> (in short <dfn>TD</dfn>), <dfn>Web of Things</dfn> (in short <b><i>WoT</i></b>),  <dfn>WoT Interface</dfn>, <dfn>Protocol Bindings</dfn>, <dfn>WoT Runtime</dfn>, <dfn data-lt="consume|consume a TD|consuming a TD">Consuming a Thing Description</dfn>, <dfn>Things Directory</dfn> etc.
-    </p>
-    <p class="note">
-      In this version of the specification, a <a>WoT Runtime</a> is assumed to run scripts that uses this API to define one or more <a>Thing</a>s that share a common event loop. Script deployment methods are out of scope of this version. In future versions, running multiple scripts (as modules) may be possible, and script deployment MAY be implemented using a manager <a>Thing</a> whose actions permit script lifecycle management operations.
-    </p>
-    <p>
-      <dfn>JSON-LD</dfn> is defined in [[!JSON-LD]] as a JSON document that is augmented with support for Linked Data by providing a <code>@context</code> property with a defining URI .
-      </dd>
-    </p>
-    <p>
-      The terms <a href="http://www.w3.org/TR/url-1/"><dfn>URL</dfn></a> and
-      <a href="https://url.spec.whatwg.org/#concept-url-path">
-      <dfn>URL path</dfn></a> are defined in [[!URL]].
-    </p>
-    <p>
-      The following terms are defined in [[!HTML5]] and are used in the context of browser implementations:
-      <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">
-      <dfn>browsing context</dfn></a>,
-
-      <a href="https://html.spec.whatwg.org/#top-level-browsing-context">
-      <dfn>top-level browsing context</dfn></a>,
-
-      <a href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">
-      <dfn>global object</dfn></a>,
-
-      <a href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">
-      <dfn>incumbent settings object</dfn></a>,
-
-      <a href="https://html.spec.whatwg.org/#document">
-      <dfn>Document</dfn></a>,
-
-      <a href="http://www.w3.org/TR/2011/WD-html5-20110113/urls.html#document-base-url">
-      <dfn>document base URL</dfn></a>,
-
-      <a href="https://html.spec.whatwg.org/#window">
-      <dfn>Window</dfn></a>,
-
-      <a href="https://html.spec.whatwg.org/#windowproxy">
-      <dfn>WindowProxy</dfn></a>,
-
-      <a href="https://html.spec.whatwg.org/#origin">
-      <dfn>origin</dfn></a>,
-
-      <a href="https://html.spec.whatwg.org/#ascii-serialisation-of-an-origin">
-      <dfn>ASCII serialized origin</dfn></a>,
-
-      executing algorithms <a href="https://html.spec.whatwg.org/#in-parallel">
-      <dfn>in parallel</dfn></a>,
-
-      <a href="https://html.spec.whatwg.org/#queue-a-task">
-      <dfn>queue a task</dfn></a>,
-
-      <a href="https://html.spec.whatwg.org/#task-source">
-      <dfn>task source</dfn></a>,
-
-      <a href="https://html.spec.whatwg.org/#the-iframe-element">
-      <dfn>iframe</dfn></a>,
-
-      <a href="https://html.spec.whatwg.org/#valid-mime-type">
-      <dfn>valid MIME type</dfn></a>.
-    </p>
-    <p>
-      A <a>browsing context</a> refers to the environment in which
-      <a>Document</a> objects are presented to the user. A given
-      <a>browsing context</a> has a single <code><a>WindowProxy</a></code> object,
-      but it can have many <code><a>Document</a></code> objects, with their associated
-      <code><a>Window</a></code> objects. The <a>script execution context</a>
-      associated with the <i>browsing context</i> identifies the entity which
-      invokes this API, which can be a <i>web app</i>, a <i>web page</i>, or an
-      <a>iframe</a>.
-    </p>
-    <p>
-      The term
-      <a href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#secure-context">
-      <dfn>secure context</dfn></a> is defined in [[!WEBAPPSEC]].
-    </p>
-    <p>
-      <a href="https://tc39.github.io/ecma262/#sec-error-objects">
-      <dfn>Error</dfn>, <dfn>EvalError</dfn>, <dfn>RangeError</dfn>, <dfn>ReferenceError</dfn>, <dfn>SyntaxError</dfn>, <dfn>TypeError</dfn>, <dfn>URIError</dfn>
-      </a>,
-      <a href="https://tc39.github.io/ecma262/#sec-execution-contexts">
-        <dfn>script execution context</dfn></a>,
-      <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects">
-        <dfn>Promise</dfn></a>,
-      <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-json-object">
-        <dfn>JSON</dfn></a>,
-      <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-json.stringify">
-        <dfn>JSON.stringify</dfn></a> and
-      <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-json.parse">
-        <dfn>JSON.parse</dfn></a>
-      are defined in [[!ECMASCRIPT]].
-    </p>
-    <p>
-      <a href="http://heycam.github.io/webidl/#idl-DOMString"><dfn>DOMString</dfn></a>,
-      <a href="https://heycam.github.io/webidl/#idl-USVString"><dfn>USVString</dfn></a>,
-      <a href="http://heycam.github.io/webidl/#idl-ArrayBuffer"><dfn>ArrayBuffer</dfn></a>,
-      <a href="http://heycam.github.io/webidl/#common-BufferSource"><dfn>BufferSource</dfn></a> and
-      <a href="http://heycam.github.io/webidl/#idl-any"><dfn>any</dfn></a> are defined in [[!WEBIDL]].
-    </p>
-    <p>
-      The term <b><i>event</i></b> and the <dfn>Event</dfn> object are defined in [DOM](https://www.w3.org/TR/DOM-Level-2-Events/events.html) and [Node.js](https://nodejs.org/api/events.html).
-    </p>
-    <p class="note">
-      This specification uses the convention that an event listener will receive an [Event](https://www.w3.org/TR/DOM-Level-2-Events/ecma-script-binding.html) object. This should work both in a browser environment and in a Node.js like environment.
-    </p>
-    <p>
-      <a href="https://github.com/tc39/proposal-observable"><dfn>Observable</dfn>s</a> are proposed to be included in ECMAScript.
-    </p>
-    <p>
-      The algorithms <a href="http://www.w3.org/TR/encoding/#utf-8-encode">
-      <dfn>utf-8 encode</dfn></a>, and
-      <a href="http://www.w3.org/TR/encoding/#utf-8-decode">
-      <dfn>utf-8 decode</dfn></a> are defined in [[!ENCODING]].
-    </p>
-    <p>
-      <dfn>IANA media type</dfn>s (formerly known as MIME types) are defined in
-      <a href="http://tools.ietf.org/html/rfc2046">RFC2046</a>.
-    </p>
-  </section>
-
   <section id="introduction"> <h2>Introduction</h2>
     <p>
       The overall WoT concepts are described in the [WoT Architecture](https://w3c.github.io/wot-architecture/) document.
-      The Web of Things is made of entities (<a>Thing</a>s) that can describe their capabilities in a machine-interpretable format, the <a>Thing Description</a> (TD). By <a>consuming a TD</a>, a client <a>Thing</a> creates a runtime resource model that allows accessing the properties, actions and events exposed by the server <a>Thing</a>. Exposing a <a>Thing</a> requires defining a <a>Thing Description</a> and instantiating a software stack needed to serve requests for accessing the exposed properties, actions and events. This specification describes how to expose and consume <a>Thing</a>s by a script. Support for scripting is optional for WoT devices.
+      The Web of Things is made of entities (<a>Thing</a>s) that can describe their capabilities in a machine-interpretable format, the <a>Thing Description</a> (TD) and expose these capabilities through the <a>WoT Interface</a>.
+    </p>
+    <p>
+      By <a>consuming a TD</a>, a client <a>Thing</a> creates a runtime resource model that allows accessing the properties, actions and events exposed by the server <a>Thing</a>. Exposing a <a>Thing</a> requires defining a <a>Thing Description</a> and instantiating a software stack needed to serve requests for accessing the exposed properties, actions and events. This specification describes how to expose and consume <a>Thing</a>s by a script. Support for scripting is optional for WoT devices.
     </p>
     <p class="note">
       Typically scripts are meant to be used on devices able to provide resources (with a <a>WoT interface</a>) for managing (installing, updating, running) scripts, such as bridges or gateways that expose and control simpler devices as WoT <a>Thing</a>s.
@@ -1135,7 +1001,150 @@
       The trust model, attacker model, threat model and possible mitigation
       proposals for WoT in general, and the Scripting API in particular are presented in the [WoT Security and Privacy](https://github.com/w3c/wot/tree/master/security-privacy) documents and the [WoT Architecture](https://w3c.github.io/wot-architecture/) documents [Security Considerations](https://w3c.github.io/wot-architecture/#security-considerations) section.
     </p>
-    <p class="ednote">The security section will be completed later.</p>
+    <p class="ednote">The security section is under development.</p>
+  </section>
+
+  <section> <h2>Terminology and conventions</h2>
+    <p>
+      The generic WoT terminology is defined in [[!WOT-ARCHITECTURE]]: <dfn data-lt="Things">Thing</dfn>, <dfn data-lt="Thing Descriptions">Thing Description</dfn> (in short <dfn>TD</dfn>), <dfn>Web of Things</dfn> (in short <b><i>WoT</i></b>),  <dfn>WoT Interface</dfn>, <dfn>Protocol Bindings</dfn>, <dfn>WoT Runtime</dfn>, <dfn data-lt="consume|consume a TD|consuming a TD">Consuming a Thing Description</dfn>, <dfn>Things Directory</dfn> etc.
+    </p>
+    <p class="note">
+      In this version of the specification, a <a>WoT Runtime</a> is assumed to run scripts that uses this API to define one or more <a>Thing</a>s that share a common event loop. Script deployment methods are out of scope of this version. In future versions, running multiple scripts (as modules) may be possible, and script deployment MAY be implemented using a manager <a>Thing</a> whose actions permit script lifecycle management operations.
+    </p>
+    <p>
+      <dfn>JSON-LD</dfn> is defined in [[!JSON-LD]] as a JSON document that is augmented with support for Linked Data by providing a <code>@context</code> property with a defining URI .
+      </dd>
+    </p>
+    <p>
+      The terms <a href="http://www.w3.org/TR/url-1/"><dfn>URL</dfn></a> and
+      <a href="https://url.spec.whatwg.org/#concept-url-path">
+      <dfn>URL path</dfn></a> are defined in [[!URL]].
+    </p>
+    <p>
+      The following terms are defined in [[!HTML5]] and are used in the context of browser implementations:
+      <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">
+      <dfn>browsing context</dfn></a>,
+
+      <a href="https://html.spec.whatwg.org/#top-level-browsing-context">
+      <dfn>top-level browsing context</dfn></a>,
+
+      <a href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">
+      <dfn>global object</dfn></a>,
+
+      <a href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">
+      <dfn>incumbent settings object</dfn></a>,
+
+      <a href="https://html.spec.whatwg.org/#document">
+      <dfn>Document</dfn></a>,
+
+      <a href="http://www.w3.org/TR/2011/WD-html5-20110113/urls.html#document-base-url">
+      <dfn>document base URL</dfn></a>,
+
+      <a href="https://html.spec.whatwg.org/#window">
+      <dfn>Window</dfn></a>,
+
+      <a href="https://html.spec.whatwg.org/#windowproxy">
+      <dfn>WindowProxy</dfn></a>,
+
+      <a href="https://html.spec.whatwg.org/#origin">
+      <dfn>origin</dfn></a>,
+
+      <a href="https://html.spec.whatwg.org/#ascii-serialisation-of-an-origin">
+      <dfn>ASCII serialized origin</dfn></a>,
+
+      executing algorithms <a href="https://html.spec.whatwg.org/#in-parallel">
+      <dfn>in parallel</dfn></a>,
+
+      <a href="https://html.spec.whatwg.org/#queue-a-task">
+      <dfn>queue a task</dfn></a>,
+
+      <a href="https://html.spec.whatwg.org/#task-source">
+      <dfn>task source</dfn></a>,
+
+      <a href="https://html.spec.whatwg.org/#the-iframe-element">
+      <dfn>iframe</dfn></a>,
+
+      <a href="https://html.spec.whatwg.org/#valid-mime-type">
+      <dfn>valid MIME type</dfn></a>.
+    </p>
+    <p>
+      A <a>browsing context</a> refers to the environment in which
+      <a>Document</a> objects are presented to the user. A given
+      <a>browsing context</a> has a single <code><a>WindowProxy</a></code> object,
+      but it can have many <code><a>Document</a></code> objects, with their associated
+      <code><a>Window</a></code> objects. The <a>script execution context</a>
+      associated with the <i>browsing context</i> identifies the entity which
+      invokes this API, which can be a <i>web app</i>, a <i>web page</i>, or an
+      <a>iframe</a>.
+    </p>
+    <p>
+      The term
+      <a href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#secure-context">
+      <dfn>secure context</dfn></a> is defined in [[!WEBAPPSEC]].
+    </p>
+    <p>
+      <a href="https://tc39.github.io/ecma262/#sec-error-objects">
+      <dfn>Error</dfn>, <dfn>EvalError</dfn>, <dfn>RangeError</dfn>, <dfn>ReferenceError</dfn>, <dfn>SyntaxError</dfn>, <dfn>TypeError</dfn>, <dfn>URIError</dfn>
+      </a>,
+      <a href="https://tc39.github.io/ecma262/#sec-execution-contexts">
+        <dfn>script execution context</dfn></a>,
+      <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects">
+        <dfn>Promise</dfn></a>,
+      <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-json-object">
+        <dfn>JSON</dfn></a>,
+      <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-json.stringify">
+        <dfn>JSON.stringify</dfn></a> and
+      <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-json.parse">
+        <dfn>JSON.parse</dfn></a>
+      are defined in [[!ECMASCRIPT]].
+    </p>
+    <p>
+      <a href="http://heycam.github.io/webidl/#idl-DOMString"><dfn>DOMString</dfn></a>,
+      <a href="https://heycam.github.io/webidl/#idl-USVString"><dfn>USVString</dfn></a>,
+      <a href="http://heycam.github.io/webidl/#idl-ArrayBuffer"><dfn>ArrayBuffer</dfn></a>,
+      <a href="http://heycam.github.io/webidl/#common-BufferSource"><dfn>BufferSource</dfn></a> and
+      <a href="http://heycam.github.io/webidl/#idl-any"><dfn>any</dfn></a> are defined in [[!WEBIDL]].
+    </p>
+    <p>
+      The term <b><i>event</i></b> and the <dfn>Event</dfn> object are defined in [DOM](https://www.w3.org/TR/DOM-Level-2-Events/events.html) and [Node.js](https://nodejs.org/api/events.html).
+    </p>
+    <p class="note">
+      This specification uses the convention that an event listener will receive an [Event](https://www.w3.org/TR/DOM-Level-2-Events/ecma-script-binding.html) object. This should work both in a browser environment and in a Node.js like environment.
+    </p>
+    <p>
+      <a href="https://github.com/tc39/proposal-observable"><dfn>Observable</dfn>s</a> are proposed to be included in ECMAScript.
+    </p>
+    <p>
+      The algorithms <a href="http://www.w3.org/TR/encoding/#utf-8-encode">
+      <dfn>utf-8 encode</dfn></a>, and
+      <a href="http://www.w3.org/TR/encoding/#utf-8-decode">
+      <dfn>utf-8 decode</dfn></a> are defined in [[!ENCODING]].
+    </p>
+    <p>
+      <dfn>IANA media type</dfn>s (formerly known as MIME types) are defined in
+      <a href="http://tools.ietf.org/html/rfc2046">RFC2046</a>.
+    </p>
+  </section>
+
+  <section id="conformance">
+    <p>
+      This document defines conformance criteria that apply to a single product: the <dfn>UA</dfn> (user agent) that implements the interfaces it contains.
+    </p>
+    <p>
+      This specification can be used for implementing the WoT Scripting API in multiple programming languages. The interface definitions are specified in [[!WEBIDL]].
+    </p>
+    <p>
+      The user agent (UA) may be implemented in the browser, or in a separate runtime environment, such as [Node.js](https://nodejs.org/en/) or small embedded runtimes.
+    </p>
+    <p>
+      Implementations that use ECMAScript executed in a browser to implement the APIs defined in this document MUST implement them in a manner consistent with the ECMAScript Bindings defined in the Web IDL specification [[!WEBIDL]].
+    </p>
+    <p>
+      Implementations that use TypeScript or ECMAScript in a runtime to implement the APIs defined in this document MUST implement them in a manner consistent with the TypeScript Bindings defined in the TypeScript specification [[!TYPESCRIPT]].
+    </p>
+    <p>
+      This document serves a general description of the WoT Scripting API. Language and runtime specific issues are discussed in separate extensions of this document.
+    </p>
   </section>
 
   <section class="appendix" id="Changes"><h2>Changes</h2>

--- a/index.html
+++ b/index.html
@@ -104,10 +104,10 @@
       The <a>Web of Things</a> (WoT) provides layered interoperability between <a>Things</a> by using the <a>WoT Interface</a>s.
     </p>
     <p>
-      This specification describes a convenient programming interface representing the <a>WoT Interface</a> that allows scripts run on a <a>Thing</a> to discover and access other <a>Thing</a>s through a <a>Client API</a>, provide resources characterized by properties, actions and events through a <a>Server API</a>, and access locally attached hardware.
+      This specification describes a programming interface representing the <a>WoT Interface</a> that allows scripts run on a <a>Thing</a> to discover and consume (retrieve) other <a>Thing</a>s and to expose <a>Things</a> characterized by properties, actions and events.
     </p>
     <p>
-      Scripting is an optional building block in WoT and it is typically used in gateways that are able to run a <a>WoT Runtime</a> and <a href="https://w3c.github.io/wot-scripting-api/script-manager/")>script management</a>, providing a convenient way to extend WoT support to new types of endpoints and implement WoT applications like <a href="https://w3c.github.io/wot-scripting-api/script-manager/")>Things Directory</a>.
+      Scripting is an optional "convenience" building block in WoT and it is typically used in gateways that are able to run a <a>WoT Runtime</a> and <a href="https://w3c.github.io/wot-scripting-api/script-manager/")>script management</a>, providing a convenient way to extend WoT support to new types of endpoints and implement WoT applications like <a href="https://w3c.github.io/wot-scripting-api/script-manager/")>Thing Directory</a>.
     </p>
   </section>
 
@@ -120,10 +120,13 @@
   <section id="introduction"> <h2>Introduction</h2>
     <p>
       The overall WoT concepts are described in the [WoT Architecture](https://w3c.github.io/wot-architecture/) document.
-      The Web of Things is made of entities (<a>Thing</a>s) that can describe their capabilities in a machine-interpretable format, the <a>Thing Description</a> (TD) and expose these capabilities through the <a>WoT Interface</a>.
+      The Web of Things is made of entities (<a>Thing</a>s) that can describe their capabilities in a machine-interpretable format, the <a>Thing Description</a> (TD) and expose these capabilities through the <a>WoT Interface</a>. Support for scripting is optional for WoT devices.
     </p>
     <p>
-      By <a>consuming a TD</a>, a client <a>Thing</a> creates a runtime resource model that allows accessing the properties, actions and events exposed by the server <a>Thing</a>. Exposing a <a>Thing</a> requires defining a <a>Thing Description</a> and instantiating a software stack needed to serve requests for accessing the exposed properties, actions and events. This specification describes how to expose and consume <a>Thing</a>s by a script. Support for scripting is optional for WoT devices.
+      By <a>consuming a TD</a>, a client <a>Thing</a> creates a runtime resource model that allows accessing the properties, actions and events exposed by the server <a>Thing</a>.
+    </p>
+    <p>
+      Exposing a <a>Thing</a> requires defining a <a>Thing Description</a> and instantiating a software stack needed to serve requests for accessing the exposed properties, actions and events. This specification describes how to expose and consume <a>Thing</a>s by a script.
     </p>
     <p class="note">
       Typically scripts are meant to be used on devices able to provide resources (with a <a>WoT interface</a>) for managing (installing, updating, running) scripts, such as bridges or gateways that expose and control simpler devices as WoT <a>Thing</a>s.
@@ -164,7 +167,7 @@
           </li>
         </ul>
       </li>
-      <li>Retrieve a thing.</li>
+      <li>Consume a thing.</li>
       <li>Create and expose a local <a>Thing</a> based on a <a>Thing Description</a>.</li>
       <li>Programmatically create and expose a local <a>Thing</a>. This may include the following use cases:
         <ul>
@@ -204,8 +207,8 @@
   </section>
 
   <section data-dfn-for="WoT">
-    <h2>The <dfn>WoT</dfn> interface</h2>
-    <p>The WoT object is the main API entry point and it is exposed by an implementation of the <a>WoT Runtime</a>. The <dfn>WoT object</dfn> has no internal state and provides methods for discovering, retrieving, and creating a <a>Thing</a>.
+    <h2>The <dfn>WoT</dfn> object</h2>
+    <p>The WoT object is the main API entry point and it is exposed by an implementation of the <a>WoT Runtime</a>. The <dfn>WoT object</dfn> has no internal state and provides methods for discovering, consuming and exposing a <a>Thing</a>.
     </p>
     <p class="note">
        Browser implementations SHOULD use a namespace object such as `wot`, and [Node.js](https://nodejs.org/en/)-like runtimes MAY provide the API object through the [`require()`](https://nodejs.org/api/modules.html) or [`import`](http://www.ecma-international.org/ecma-262/6.0/#sec-imports) mechanism.
@@ -215,8 +218,8 @@
       // [NamespaceObject]
       interface WoT {
         Observable&lt;ConsumedThing&gt; discover(optional ThingFilter filter);
-        Promise&lt;ConsumedThing&gt; retrieve(USVString url);
-        Promise&lt;ExposedThing&gt; createExposedThing(ThingInit init);
+        Promise&lt;ConsumedThing&gt; consume(USVString url);
+        Promise&lt;ExposedThing&gt; expose(ThingInit init);
       };
     </pre>
 
@@ -245,7 +248,7 @@
           The <dfn>method</dfn> property represents the discovery type that should be used in the discovery process. The possible values are defined by the <code><a>DiscoveryMethod</a></code> enumeration that can be extended by string values defined by solutions (with no guarantee of interoperability).
         </p>
         <p>
-          The <dfn>url</dfn> property represents additional information for the discovery method, such as the URL of the directory server to be used.
+          The <dfn>url</dfn> property represents additional information for the discovery method, such as the URL of the <a>Thing Directory</a> server to be used.
         </p>
         <p>
           The <dfn>description</dfn> property represents additional information for the discovery method in the form of a set of key-value pairs, as defined in the <a>Thing Description</a>.
@@ -285,13 +288,13 @@
       </section>
     </section> <!-- Discovery -->
 
-    <section> <h3> The <dfn>retrieve()</dfn> method</h3>
+    <section> <h3> The <dfn>consume()</dfn> method</h3>
       <p>
         Accepts an <code>url</code> argument and returns a <code><a>Promise</a></code> of a <a>ConsumedThing</a>.
       </p>
     </section>
 
-    <section> <h3>The <dfn>createExposedThing()</dfn> method</h3>
+    <section> <h3>The <dfn>expose()</dfn> method</h3>
       <p>
         Returns a <code><a>Promise</a></code> of a locally created <a>ExposedThing</a> based on the provided initialization paramaters.
       </p>
@@ -356,221 +359,218 @@
     </section> <!-- Examples -->
   </section> <!-- WoT API -->
 
-  <section> <h2>The Thing <dfn>Client API</dfn></h2>
+  <section data-dfn-for="ConsumedThing">
+    <h2>The <dfn>ConsumedThing</dfn> interface</h2>
     <p>
-      The <a>ConsumedThing</a> interface is basically for sending requests to servers in order to retrieve or update properties, invoke actions, and observe properties, actions and events.
+      The <a>ConsumedThing</a> interface is a client API for sending requests to servers in order to retrieve or update properties, invoke actions, and observe properties, actions and events.
+    </p>
+    <pre class="idl">
+      interface ConsumedThing {
+        readonly attribute DOMString name;
+        readonly attribute USVString url;
+        readonly attribute ThingDescription description;
+        Promise&lt;any&gt; invokeAction(DOMString name, any parameters);
+        Promise&lt;void&gt; setProperty(DOMString name, any value);
+        Promise&lt;any&gt; getProperty(DOMString name);
+        ConsumedThing addListener(DOMString eventName, ThingEventListener listener);
+        ConsumedThing removeListener(DOMString eventName, ThingEventListener listener);
+        ConsumedThing removeAllListeners(optional DOMString eventName);
+        Observable observe(DOMString name, RequestType requestType);
+      };
+      callback ThingEventListener = void (Event event);
+    </pre>
+    <p>
+      Represents a local proxy object of the remote <a>Thing</a>.
+      <ul>
+        <li>The <dfn>name</dfn> read-only attribute represents the name of the <a>Thing</a>.</li>
+        <li>The <dfn>url</dfn> read-only attribute represents the URL of the <a>Thing</a>.</li>
+        <li>
+          The <dfn>description</dfn> attribute read-only attribute represents the description of the <a>Thing</a>.
+          <p class="ednote">
+            Parsing and exposing <a>Thing Description</a>s is discussed in [Issue 38](https://github.com/w3c/wot-scripting-api/issues/38).</p>
+        </li>
+      </ul>
     </p>
 
-    <section data-dfn-for="ConsumedThing">
-      <h2>The <dfn>ConsumedThing</dfn> interface</h2>
-      <pre class="idl">
-        interface ConsumedThing {
-          readonly attribute DOMString name;
-          readonly attribute USVString url;
-          readonly attribute ThingDescription description;
-          Promise&lt;any&gt; invokeAction(DOMString name, any parameters);
-          Promise&lt;void&gt; setProperty(DOMString name, any value);
-          Promise&lt;any&gt; getProperty(DOMString name);
-          ConsumedThing addListener(DOMString eventName, ThingEventListener listener);
-          ConsumedThing removeListener(DOMString eventName, ThingEventListener listener);
-          ConsumedThing removeAllListeners(optional DOMString eventName);
-          Observable observe(DOMString name, RequestType requestType);
-        };
-        callback ThingEventListener = void (Event event);
-      </pre>
+    <section> <h3>The <dfn>invokeAction()</dfn> method</h3>
       <p>
-        Represents a local proxy object of the remote <a>Thing</a>.
-        <ul>
-          <li>The <dfn>name</dfn> read-only attribute represents the name of the <a>Thing</a>.</li>
-          <li>The <dfn>url</dfn> read-only attribute represents the URL of the <a>Thing</a>.</li>
-          <li>
-            The <dfn>description</dfn> attribute read-only attribute represents the description of the <a>Thing</a>.
-            <p class="ednote">
-              Parsing and exposing <a>Thing Description</a>s is discussed in [Issue 38](https://github.com/w3c/wot-scripting-api/issues/38).</p>
-          </li>
-        </ul>
+        Takes the action name as the <var>name</var> argument and the list of parameters, then requests from the underlying platform and the <a>Protocol Bindings</a> to invoke the action on the remote <a>Thing</a> and return the result. Returns a <code><a>Promise</a></code> that resolves with the return value or rejects with an <a>Error</a>.
+      </p>
+    </section>
+
+    <section> <h3>The <dfn>setProperty()</dfn> method</h3>
+      <p>
+        Takes the property name as the <var>name</var> argument and the new value as the <var>value</var> argument, then requests from the underlying platform and the <a>Protocol Bindings</a> to update the property on the remote <a>Thing</a> and return the result. Returns a <code><a>Promise</a></code> that resolves on success or rejects with an <a>Error</a>.
+      </p>
+    </section>
+
+    <section> <h3>The <dfn>getProperty()</dfn> method</h3>
+      <p>
+        Takes the property name as the <var>name</var> argument, then requests from the underlying platform  and the <a>Protocol Bindings</a> to retrieve the property on the remote <a>Thing</a> and return the result. Returns a <code><a>Promise</a></code> that resolves with the property value or rejects with an <a>Error</a>.
+      </p>
+    </section>
+
+    <section> <h3>The <dfn>addListener()</dfn> method</h3>
+      <p>
+        Adds the listener provided in the argument <var>listener</var> to the event name provided in the argument <var>eventName</var>.
+      </p>
+    </section>
+
+    <section> <h3>The <dfn>removeListener()</dfn> method</h3>
+      <p>
+        Removes a listener from the event identified by the provided <var>eventName</var> and <var>listener</var> argument.
+      </p>
+    </section>
+
+    <section> <h3>The <dfn>removeAllListeners()</dfn> method</h3>
+      <p>
+        Removes all listeners for the event provided by the <var>eventName</var> optional argument, or if that was not provided, then removes all listeners from all events.
+      </p>
+    </section>
+
+    <section> <h3>The <dfn>observe()</dfn> method</h3>
+      <p>
+        Returns an <a>Observable</a> for the property, event or action specified in the <var>name</var> argument, allowing subscribing and unsubscribing to notifications. The <var>requestType</var> specifies whether a property, an event or an action is observed.
+      </p>
+      <p class="ednote">
+        The <code>observe()</code> method could replace <code>addListener()</code> and <code>removeListener()</code>, though they could be kept for convenience.
+      </p>
+    </section>
+
+    <section data-dfn-for="ThingEventListener">
+      <h2>The <dfn>ThingEventListener</dfn> callback</h2>
+      <p>
+        A function called with an <a>Event</a> object when an event is emitted.
+      </p>
+    </section>
+
+    <section> <h2>Events</h2>
+      <p>
+        Clients can subscribe to the events defined in <a href="#events-supported-by-exposedthing">ExposedThing events</a>. The event types are described in this section.
       </p>
 
-      <section> <h3>The <dfn>invokeAction()</dfn> method</h3>
-        <p>
-          Takes the action name as the <var>name</var> argument and the list of parameters, then requests from the underlying platform and the <a>Protocol Bindings</a> to invoke the action on the remote <a>Thing</a> and return the result. Returns a <code><a>Promise</a></code> that resolves with the return value or rejects with an <a>Error</a>.
-        </p>
+      <section data-dfn-for="PropertyChangeEvent">
+        <h3>The <dfn>PropertyChangeEvent</dfn> interface</h3>
+        <pre class="idl">
+          [Constructor(any value)]
+          interface PropertyChangeEvent: Event {
+              readonly attribute any value;
+          };
+        </pre>
+        <p>The <var>name</var> attribute of the event is <code>"propertychange"</code>.</p>
+        <p>The <dfn>value</dfn> attribute represents the new value of the property.</p>
       </section>
 
-      <section> <h3>The <dfn>setProperty()</dfn> method</h3>
+      <section data-dfn-for="ActionInvocationEvent">
+        <h2>The <dfn>ActionInvocationEvent</dfn> interface</h2>
+        <pre class="idl">
+          [Constructor(ActionInvocationEventInit init)]
+          interface ActionInvocationEvent: Event {
+              readonly attribute ActionInvocationEventInit data;
+          };
+        </pre>
         <p>
-          Takes the property name as the <var>name</var> argument and the new value as the <var>value</var> argument, then requests from the underlying platform and the <a>Protocol Bindings</a> to update the property on the remote <a>Thing</a> and return the result. Returns a <code><a>Promise</a></code> that resolves on success or rejects with an <a>Error</a>.
+            The <dfn>data</dfn> attribute represents the notification data from the action invocation.
         </p>
-      </section>
-
-      <section> <h3>The <dfn>getProperty()</dfn> method</h3>
-        <p>
-          Takes the property name as the <var>name</var> argument, then requests from the underlying platform  and the <a>Protocol Bindings</a> to retrieve the property on the remote <a>Thing</a> and return the result. Returns a <code><a>Promise</a></code> that resolves with the property value or rejects with an <a>Error</a>.
-        </p>
-      </section>
-
-      <section> <h3>The <dfn>addListener()</dfn> method</h3>
-        <p>
-          Adds the listener provided in the argument <var>listener</var> to the event name provided in the argument <var>eventName</var>.
-        </p>
-      </section>
-
-      <section> <h3>The <dfn>removeListener()</dfn> method</h3>
-        <p>
-          Removes a listener from the event identified by the provided <var>eventName</var> and <var>listener</var> argument.
-        </p>
-      </section>
-
-      <section> <h3>The <dfn>removeAllListeners()</dfn> method</h3>
-        <p>
-          Removes all listeners for the event provided by the <var>eventName</var> optional argument, or if that was not provided, then removes all listeners from all events.
-        </p>
-      </section>
-
-      <section> <h3>The <dfn>observe()</dfn> method</h3>
-        <p>
-          Returns an <a>Observable</a> for the property, event or action specified in the <var>name</var> argument, allowing subscribing and unsubscribing to notifications. The <var>requestType</var> specifies whether a property, an event or an action is observed.
-        </p>
-        <p class="ednote">
-          The <code>observe()</code> method could replace <code>addListener()</code> and <code>removeListener()</code>, though they could be kept for convenience.
-        </p>
-      </section>
-
-      <section data-dfn-for="ThingEventListener">
-        <h2>The <dfn>ThingEventListener</dfn> callback</h2>
-        <p>
-          A function called with an <a>Event</a> object when an event is emitted.
-        </p>
-      </section>
-
-      <section> <h2>Events</h2>
-        <p>
-          Client can subscribe to the events defined in <a href="#events-supported-by-exposedthing">ExposedThing events</a>. The event types are described in this section.
-        </p>
-
-        <section data-dfn-for="PropertyChangeEvent">
-          <h3>The <dfn>PropertyChangeEvent</dfn> interface</h3>
+        <section data-dfn-for="ActionInvocationEventInit">
+          <h2>The <dfn>ActionInvocationEventInit</dfn> dictionary</h2>
           <pre class="idl">
-            [Constructor(any value)]
-            interface PropertyChangeEvent: Event {
-                readonly attribute any value;
+            dictionary ActionInvocationEventInit {
+                DOMString actionName;
+                any returnValue;
             };
           </pre>
-          <p>The <var>name</var> attribute of the event is <code>"propertychange"</code>.</p>
-          <p>The <dfn>value</dfn> attribute represents the new value of the property.</p>
-        </section>
-
-        <section data-dfn-for="ActionInvocationEvent">
-          <h2>The <dfn>ActionInvocationEvent</dfn> interface</h2>
-          <pre class="idl">
-            [Constructor(ActionInvocationEventInit init)]
-            interface ActionInvocationEvent: Event {
-                readonly attribute ActionInvocationEventInit data;
-            };
-          </pre>
-          <p>
-              The <dfn>data</dfn> attribute represents the notification data from the action invocation.
+          <p class="ednote">
+            Action parameters could be also included, but it's debateble because privacy reasons.
           </p>
-          <section data-dfn-for="ActionInvocationEventInit">
-            <h2>The <dfn>ActionInvocationEventInit</dfn> dictionary</h2>
-            <pre class="idl">
-              dictionary ActionInvocationEventInit {
-                  DOMString actionName;
-                  any returnValue;
-              };
-            </pre>
-            <p class="ednote">
-              Action parameters could be also included, but it's debateble because privacy reasons.
-            </p>
-            <p>
-              The <dfn>actionName</dfn> attribute represents the name of the action that has been invoked.
-            </p>
-            <p>
-              The <dfn>returnValue</dfn> attribute represents the return value of the action.
-            </p>
-          </section>
+          <p>
+            The <dfn>actionName</dfn> attribute represents the name of the action that has been invoked.
+          </p>
+          <p>
+            The <dfn>returnValue</dfn> attribute represents the return value of the action.
+          </p>
         </section>
+      </section>
 
-        <section data-dfn-for="ThingDescriptionChangeEvent">
-          <h2>The <dfn>ThingDescriptionChangeEvent</dfn> interface</h2>
+      <section data-dfn-for="ThingDescriptionChangeEvent">
+        <h2>The <dfn>ThingDescriptionChangeEvent</dfn> interface</h2>
+        <pre class="idl">
+          [Constructor(ThingDescriptionChangeEventInit init)]
+          interface ThingDescriptionChangeEvent: Event {
+              readonly attribute ThingDescriptionChangeEventInit data;
+          };
+        </pre>
+        <p>
+          The <dfn>data</dfn> attribute represents the changes that occured to the <a>Thing Description</a>.
+        </p>
+        <section data-dfn-for="ThingDescriptionChangeEventInit">
+          <h3>The <dfn>ThingDescriptionChangeEventInit</dfn> dictionary</h3>
           <pre class="idl">
-            [Constructor(ThingDescriptionChangeEventInit init)]
-            interface ThingDescriptionChangeEvent: Event {
-                readonly attribute ThingDescriptionChangeEventInit data;
+            dictionary ThingDescriptionChangeEventInit {
+                TDChangeType type;
+                TDChangeMethod method;
+                DOMString name;
+                TDChangeData data;
+                ThingDescription description;
             };
           </pre>
-          <p>
-            The <dfn>data</dfn> attribute represents the changes that occured to the <a>Thing Description</a>.
-          </p>
-          <section data-dfn-for="ThingDescriptionChangeEventInit">
-            <h3>The <dfn>ThingDescriptionChangeEventInit</dfn> dictionary</h3>
+          <ul>
+            <li>
+              The <dfn>type</dfn> attribute represents the change type, whether has it been applied on properties, actions or events.
+            </li>
+            <li>
+             The <dfn>method</dfn> attribute tells what operation has been applied, addition, removal or change.
+            </li>
+            <li>
+              The <dfn>name</dfn> attribute represents the name of the property, action or event that has changed.
+            </li>
+            <li>
+              The <dfn>description</dfn> attribute is defined for the addition and change methods, and represents the new description.
+            </li>
+            <li>
+              The <dfn>data</dfn> attribute provides the initialization data for the added or changed elements.
+            </li>
+          </ul>
+          <section data-dfn-for="TDChangeMethod">
+            <h4>The <dfn>TDChangeMethod</dfn> enumeration</h4>
             <pre class="idl">
-              dictionary ThingDescriptionChangeEventInit {
-                  TDChangeType type;
-                  TDChangeMethod method;
-                  DOMString name;
-                  TDChangeData data;
-                  ThingDescription description;
-              };
+              enum TDChangeMethod { "add", "remove", "change" };
             </pre>
             <ul>
-              <li>
-                The <dfn>type</dfn> attribute represents the change type, whether has it been applied on properties, actions or events.
-              </li>
-              <li>
-               The <dfn>method</dfn> attribute tells what operation has been applied, addition, removal or change.
-              </li>
-              <li>
-                The <dfn>name</dfn> attribute represents the name of the property, action or event that has changed.
-              </li>
-              <li>
-                The <dfn>description</dfn> attribute is defined for the addition and change methods, and represents the new description.
-              </li>
-              <li>
-                The <dfn>data</dfn> attribute provides the initialization data for the added or changed elements.
-              </li>
+              <li>The <dfn>add</dfn> value denotes addition of a property, action or event.</li>
+              <li>The <dfn>remove</dfn> value denotes removal of a property, action or event.</li>
+              <li>The <dfn>change</dfn> value denotes a change applied on a property, action or event.</li>
             </ul>
-            <section data-dfn-for="TDChangeMethod">
-              <h4>The <dfn>TDChangeMethod</dfn> enumeration</h4>
-              <pre class="idl">
-                enum TDChangeMethod { "add", "remove", "change" };
-              </pre>
-              <ul>
-                <li>The <dfn>add</dfn> value denotes addition of a property, action or event.</li>
-                <li>The <dfn>remove</dfn> value denotes removal of a property, action or event.</li>
-                <li>The <dfn>change</dfn> value denotes a change applied on a property, action or event.</li>
-              </ul>
-            </section>
-            <section data-dfn-for="TDChangeType">
-              <h4>The <dfn>TDChangeType</dfn> enumeration</h4>
-              <pre class="idl">
-                enum TDChangeType { "property", "action", "event" };
-                typedef (ThingPropertyInit or ThingActionInit or ThingEventInit) TDChangeData;
-              </pre>
-              <ul>
-                <li>The <dfn>property</dfn> value tells the operation was applied on a property definition.</li>
-                <li>The <dfn>action</dfn> value tells the operation was applied on a action definition.</li>
-                <li>The <dfn>event</dfn> value tells the operation was applied on an event definition.</li>
-              </ul>
-            </section>
-            <section data-dfn-for="TDChangeData">
-              <h4>The <dfn>TDChangeData</dfn> type</h4>
-              <p>
-                Represents the new description of the changed element. Depending on the change type, it can be either a <a>ThingPropertyInit</a>, <a>ThingActionInit</a>, or <a>ThingEventInit</a>.
-              </p>
-            </section>
-          </section> <!-- ThingDescriptionChangeEventInit -->
-        </section> <!-- ThingDescriptionChangeEvent -->
-      </section> <!-- Events -->
-    </section> <!-- ConsumedThing -->
+          </section>
+          <section data-dfn-for="TDChangeType">
+            <h4>The <dfn>TDChangeType</dfn> enumeration</h4>
+            <pre class="idl">
+              enum TDChangeType { "property", "action", "event" };
+              typedef (ThingPropertyInit or ThingActionInit or ThingEventInit) TDChangeData;
+            </pre>
+            <ul>
+              <li>The <dfn>property</dfn> value tells the operation was applied on a property definition.</li>
+              <li>The <dfn>action</dfn> value tells the operation was applied on a action definition.</li>
+              <li>The <dfn>event</dfn> value tells the operation was applied on an event definition.</li>
+            </ul>
+          </section>
+          <section data-dfn-for="TDChangeData">
+            <h4>The <dfn>TDChangeData</dfn> type</h4>
+            <p>
+              Represents the new description of the changed element. Depending on the change type, it can be either a <a>ThingPropertyInit</a>, <a>ThingActionInit</a>, or <a>ThingEventInit</a>.
+            </p>
+          </section>
+        </section> <!-- ThingDescriptionChangeEventInit -->
+      </section> <!-- ThingDescriptionChangeEvent -->
+    </section> <!-- Events -->
 
     <section>
       <h2>Examples</h2>
       <p>
         Below a <code><a>ConsumedThing</a></code> interface example is given.
       </p>
-      <pre class="example" title="Consume a Things via retrieve">
-        wot.retrieve("http://mmyservice.org/mySensor").then(
+      <pre class="example" title="Consume a Thing">
+        wot.consume("http://mmyservice.org/mySensor").then(
           error => { console.log("Discovery finished because an error: " + error.message); }
           thing => {
             console.log("Thing " + thing.name + " has been consumed.");
@@ -584,332 +584,329 @@
         );
       </pre>
     </section> <!-- Examples -->
-  </section> <!-- Thing Client API -->
+  </section> <!-- ConsumedThing -->
 
-  <section> <h2>The Thing <dfn>Server API</dfn></h2>
+  <section data-dfn-for="ExposedThing">
+    <h2>The <dfn>ExposedThing</dfn> interface</h2>
     <p>
-      The <a>ExposedThing</a> interface allows for adding properties, actions, and events to a <a>Thing</a>. Similarly, the afore mentioned interactions can be removed again or handlers can be defined for each request type.
+      The <a>ExposedThing</a> interface is the server API that allows defining request handlers, properties, actions, and events to a <a>Thing</a>.
     </p>
+    <pre class="idl">
+      typedef USVString ThingDescription;
+      callback RequestHandler = any (Request request);
+      interface ExposedThing {
+        // define Thing Description modifiers
+        ExposedThing addProperty(ThingPropertyInit property);
+        ExposedThing removeProperty(DOMString name);
+        ExposedThing addAction(ThingActionInit action);
+        ExposedThing removeAction(DOMString name);
+        ExposedThing addEvent(ThingEventInit event);
+        ExposedThing removeEvent(DOMString name);
+        // define request handlers
+        ExposedThing onRetrieveProperty(RequestHandler handler);
+        ExposedThing onUpdateProperty(RequestHandler handler);
+        ExposedThing onInvokeAction(RequestHandler handler);
+        ExposedThing onObserve(RequestHandler handler);
+        // define how to expose and run the Thing
+        Promise&lt;void&gt; register(optional USVString directory);
+        Promise&lt;void&gt; unregister(optional USVString directory);
+        Promise&lt;void&gt; start();
+        Promise&lt;void&gt; stop();
+        Promise&lt;void&gt; emitEvent(DOMString eventName, any payload);
+      };
+      ExposedThing implements ConsumedThing;
+    </pre>
 
-    <section data-dfn-for="ExposedThing">
-      <h2>The <dfn>ExposedThing</dfn> interface</h2>
+    <section data-dfn-for="ThingDescription">
+    <h3>The <dfn>ThingDescription</dfn> type</h3>
+      <p>
+        WoT provides a unified representation for data exchange between <a>Thing</a>s, standardized in the [Wot Things Description](https://w3c.github.io/wot-thing-description/) specification.
+      </p>
+      <p class="note">
+        In this version of the API, <a>Thing Description</a>s are represented as opaque strings, denoting a serialized form, for instance JSON or JSON-LD. See [Issue 38](https://github.com/w3c/wot-scripting-api/issues/38) and [Issue 45](https://github.com/w3c/wot-scripting-api/issues/45).
+        Parsing and composing <a>Thing Description</a>s is left for external libraries until standardized here.
+      </p>
+    </section>
+
+    <section data-dfn-for="Request">
+      <h3>The <dfn>Request</dfn> interface</h3>
       <pre class="idl">
-        typedef USVString ThingDescription;
-        callback RequestHandler = any (Request request);
-        interface ExposedThing {
-          // define Thing Description modifiers
-          ExposedThing addProperty(ThingPropertyInit property);
-          ExposedThing removeProperty(DOMString name);
-          ExposedThing addAction(ThingActionInit action);
-          ExposedThing removeAction(DOMString name);
-          ExposedThing addEvent(ThingEventInit event);
-          ExposedThing removeEvent(DOMString name);
-          // define request handlers
-          ExposedThing onRetrieveProperty(RequestHandler handler);
-          ExposedThing onUpdateProperty(RequestHandler handler);
-          ExposedThing onInvokeAction(RequestHandler handler);
-          ExposedThing onObserve(RequestHandler handler);
-          // define how to expose and run the Thing
-          Promise&lt;void&gt; register(optional USVString directory);
-          Promise&lt;void&gt; unregister(optional USVString directory);
-          Promise&lt;void&gt; start();
-          Promise&lt;void&gt; stop();
-          Promise&lt;void&gt; emitEvent(DOMString eventName, any payload);
+        interface Request {
+            readonly attribute RequestType type;
+            readonly attribute USVString from;
+            readonly attribute DOMString name;
+            readonly attribute Dictionary options;
+            readonly attribute any data;
+            Promise respond(any response);
+            void respondWithError(Error error);
         };
-        ExposedThing implements ConsumedThing;
       </pre>
-
-      <section data-dfn-for="ThingDescription">
-      <h3>The <dfn>ThingDescription</dfn> type</h3>
+      <p>
+        Represents an incoming request the <a>ExposedThing</a> is supposed to handle, for instance retrieving and updating properties, invoking actions and observing events (WoT interactions).
+        <ul>
+          <li>
+            The <dfn>type</dfn> attribute represents the type of the request as defined in <a>RequestType</a>.
+          </li>
+          <li>
+            The <dfn>from</dfn> attribute represents the address of the client device issuing the request. The type of the address (URL, UUID or other) is defined by the <a>Thing Description</a>.
+          </li>
+          <li>
+            The <dfn>name</dfn> attribute represents the name of the property to be retrieved or updated, or the name of the invoked action, or the event name to be observed.
+          </li>
+          <li>
+            The <dfn>options</dfn> attribute represents the options relevant to the request (e.g. the format or measurement units for the returned value) as key-value pairs. The exact format is specified by the <a>Thing Description</a>.
+          </li>
+          <li>
+            The <dfn>data</dfn> attribute represents the value of the property, or the input data (arguments) of an action. It is not used for retrieve requests and event requests, only for property update and action invocation requests.
+          </li>
+        </ul>
+      </p>
+      <section data-dfn-for="RequestType">
+        <h2>The <dfn>RequestType</dfn> enumeration</h2>
+        <pre class="idl">
+          enum RequestType { "property", "action", "event", "td" };
+        </pre>
+        <ul>
+          <li>The value "<dfn>property</dfn>" represents requests to retrieve or update a property.</li>
+          <li>The value "<dfn>action</dfn>" represents requests to invoke an action.</li>
+          <li>The value "<dfn>event</dfn>" represents requests to emit an event.</li>
+          <li>
+            The value "<dfn>td</dfn>" represents requests to change the <a>Thing Description</a>, i.e. to add, remove or modify properties, actions or events.
+            <p class="ednote">
+              This functionality is here for the sake of completeness for future versions of the API. Currently there is no corresponding functionality at the <a>ConsumedThing</a> level and it is not guaranteed that a Thing Description could be remotely changed by scripting.
+            </p>
+          </li>
+        </ul>
+      </section>
+      <section> <h3>The <dfn>respond()</dfn> method</h3>
         <p>
-          WoT provides a unified representation for data exchange between <a>Thing</a>s, standardized in the [Wot Things Description](https://w3c.github.io/wot-thing-description/) specification.
-        </p>
-        <p class="note">
-          In this version of the API, <a>Thing Description</a>s are represented as opaque strings, denoting a serialized form, for instance JSON or JSON-LD. See [Issue 38](https://github.com/w3c/wot-scripting-api/issues/38) and [Issue 45](https://github.com/w3c/wot-scripting-api/issues/45).
-          Parsing and composing <a>Thing Description</a>s is left for external libraries until standardized here.
+          Sends a positive response to the <a>Request</a> based on the <a>Protocol Bindings</a> and includes the data specified by the <var>data</var> argument.
         </p>
       </section>
+      <section> <h3>The <dfn>respondWithError()</dfn> method</h3>
+        <p>
+          Sends a negative response to the <a>Request</a> based on the <a>Protocol Bindings</a> and includes the error specified by the <var>error</var> argument.
+        </p>
+      </section>
+    </section> <!-- Request -->
 
-      <section data-dfn-for="Request">
-        <h3>The <dfn>Request</dfn> interface</h3>
+    <section data-dfn-for="RequestHandler">
+      <h3>The <dfn>RequestHandler</dfn> callback</h3>
+      <p>
+        Callback function for handling interaction requests. Receives an argument <var>request</var> of type <code><a>Request</a></code> and should return an object or value that is used by <a>Protocol Bindings</a> to reply to the request. The returned type is defined by the <a>Thing Description</a>.
+      </p>
+    </section>
+
+    <section> <h3>The <dfn>addProperty()</dfn> method</h3>
+      <p>
+        Adds a property defined by the argument and updates the <a>Thing Description</a>.
+      </p>
+      <section data-dfn-for="ThingPropertyInit">
+        <h4>The <dfn>ThingPropertyInit</dfn> dictionary</h4>
         <pre class="idl">
-          interface Request {
-              readonly attribute RequestType type;
-              readonly attribute USVString from;
-              readonly attribute DOMString name;
-              readonly attribute Dictionary options;
-              readonly attribute any data;
-              Promise respond(any response);
-              void respondWithError(Error error);
+          dictionary ThingPropertyInit {
+            DOMString name;
+            boolean configurable = true;
+            boolean enumerable = true;
+            boolean writable = true;
+            sequence&lt;SemanticType&gt; semanticTypes;
+            ThingDescription description;
+            any value;
           };
         </pre>
         <p>
-          Represents an incoming request the <a>ExposedThing</a> is supposed to handle, for instance retrieving and updating properties, invoking actions and observing events (WoT interactions).
+          Represents the <a>Thing</a> property description.
           <ul>
+            <li>The <dfn>name</dfn> attribute represents the name of the property.</li>
+            <li>The <dfn>value</dfn> attribute represents the value of the property.</li>
             <li>
-              The <dfn>type</dfn> attribute represents the type of the request as defined in <a>RequestType</a>.
+              The <dfn>configurable</dfn> attribute defines whether the property can be deleted from the object and whether its properties can be changed. The default value is <code>false</code>.
             </li>
             <li>
-              The <dfn>from</dfn> attribute represents the address of the client device issuing the request. The type of the address (URL, UUID or other) is defined by the <a>Thing Description</a>.
+              The <dfn>enumerable</dfn> attribute defines whether the property can be listed and iterated. The default value is <code>true</code>.
             </li>
             <li>
-              The <dfn>name</dfn> attribute represents the name of the property to be retrieved or updated, or the name of the invoked action, or the event name to be observed.
+              The <dfn>writable</dfn> attribute defines whether the property can be updated. The default value is <code>true</code>.
             </li>
             <li>
-              The <dfn>options</dfn> attribute represents the options relevant to the request (e.g. the format or measurement units for the returned value) as key-value pairs. The exact format is specified by the <a>Thing Description</a>.
+              The <dfn>semanticTypes</dfn> attribute represents a list of semantic type annotations (e.g. labels, classifications etc) relevant to the property, represented as <a>SemanticType</a> dictionaries.
             </li>
             <li>
-              The <dfn>data</dfn> attribute represents the value of the property, or the input data (arguments) of an action. It is not used for retrieve requests and event requests, only for property update and action invocation requests.
+              The <dfn>description</dfn> attribute represents the property description to be added to the <a>Thing Description</a>.
             </li>
           </ul>
         </p>
-        <section data-dfn-for="RequestType">
-          <h2>The <dfn>RequestType</dfn> enumeration</h2>
-          <pre class="idl">
-            enum RequestType { "property", "action", "event", "td" };
-          </pre>
-          <ul>
-            <li>The value "<dfn>property</dfn>" represents requests to retrieve or update a property.</li>
-            <li>The value "<dfn>action</dfn>" represents requests to invoke an action.</li>
-            <li>The value "<dfn>event</dfn>" represents requests to emit an event.</li>
-            <li>
-              The value "<dfn>td</dfn>" represents requests to change the <a>Thing Description</a>, i.e. to add, remove or modify properties, actions or events.
-              <p class="ednote">
-                This functionality is here for the sake of completeness for future versions of the API. Currently there is no corresponding functionality at the <a>ConsumedThing</a> level and it is not guaranteed that a Thing Description could be remotely changed by scripting.
-              </p>
-            </li>
-          </ul>
-        </section>
-        <section> <h3>The <dfn>respond()</dfn> method</h3>
-          <p>
-            Sends a positive response to the <a>Request</a> based on the <a>Protocol Bindings</a> and includes the data specified by the <var>data</var> argument.
-          </p>
-        </section>
-        <section> <h3>The <dfn>respondWithError()</dfn> method</h3>
-          <p>
-            Sends a negative response to the <a>Request</a> based on the <a>Protocol Bindings</a> and includes the error specified by the <var>error</var> argument.
-          </p>
-        </section>
-      </section> <!-- Request -->
-
-      <section data-dfn-for="RequestHandler">
-        <h3>The <dfn>RequestHandler</dfn> callback</h3>
-        <p>
-          Callback function for handling interaction requests. Receives an argument <var>request</var> of type <code><a>Request</a></code> and should return an object or value that is used by <a>Protocol Bindings</a> to reply to the request. The returned type is defined by the <a>Thing Description</a>.
-        </p>
       </section>
 
-      <section> <h3>The <dfn>addProperty()</dfn> method</h3>
-        <p>
-          Adds a property defined by the argument and updates the <a>Thing Description</a>.
-        </p>
-        <section data-dfn-for="ThingPropertyInit">
-          <h4>The <dfn>ThingPropertyInit</dfn> dictionary</h4>
-          <pre class="idl">
-            dictionary ThingPropertyInit {
-              DOMString name;
-              boolean configurable = true;
-              boolean enumerable = true;
-              boolean writable = true;
-              sequence&lt;SemanticType&gt; semanticTypes;
-              ThingDescription description;
-              any value;
-            };
-          </pre>
-          <p>
-            Represents the <a>Thing</a> property description.
-            <ul>
-              <li>The <dfn>name</dfn> attribute represents the name of the property.</li>
-              <li>The <dfn>value</dfn> attribute represents the value of the property.</li>
-              <li>
-                The <dfn>configurable</dfn> attribute defines whether the property can be deleted from the object and whether its properties can be changed. The default value is <code>false</code>.
-              </li>
-              <li>
-                The <dfn>enumerable</dfn> attribute defines whether the property can be listed and iterated. The default value is <code>true</code>.
-              </li>
-              <li>
-                The <dfn>writable</dfn> attribute defines whether the property can be updated. The default value is <code>true</code>.
-              </li>
-              <li>
-                The <dfn>semanticTypes</dfn> attribute represents a list of semantic type annotations (e.g. labels, classifications etc) relevant to the property, represented as <a>SemanticType</a> dictionaries.
-              </li>
-              <li>
-                The <dfn>description</dfn> attribute represents the property description to be added to the <a>Thing Description</a>.
-              </li>
-            </ul>
-          </p>
-        </section>
-
-        <section data-dfn-for="SemanticType">
-          <h4>The <dfn>SemanticType</dfn> dictionary</h4>
-          <pre class="idl">
-            dictionary SemanticType {
-              DOMString name;
-              USVString context;
-            };
-          </pre>
-          <p>
-            Represents a semantic type annotation, containing a name and a context.
-            <ul>
-              <li>The <dfn>name</dfn> attribute represents the name of the semantic type in the given context.</li>
-              <li>The <dfn>context</dfn> attribute represents an URL link to the context of the semantic classification.</li>
-            </ul>
-          </p>
-          <p class="ednote">
-            Semantic type examples to be added.
-          </p>
-        </section>
-      </section> <!-- addProperty() -->
-
-      <section> <h3>The <dfn>removeProperty()</dfn> method</h3>
-        <p>
-          Removes the property specified by the <code>name</code> argument, updates the <a>Thing Description</a> and returns the object.
-        </p>
-      </section>
-
-      <section> <h3>The <dfn>addAction()</dfn> method</h3>
-        <p>
-          Adds an action to the <a>Thing</a> object as defined by the <code>action</code> argument of type <a>ThingActionInit</a> and updates the <a>Thing Description</a>.
-        </p>
-        <section data-dfn-for="ThingActionInit">
-          <h4>The <dfn>ThingActionInit</dfn> dictionary</h4>
-          <pre class="idl">
-            dictionary ThingActionInit {
-              DOMString name;
-              ThingDescription inputDataDescription;
-              ThingDescription outputDataDescription;
-              sequence&lt;SemanticType&gt; semanticTypes;
-              Function action;
-            };
+      <section data-dfn-for="SemanticType">
+        <h4>The <dfn>SemanticType</dfn> dictionary</h4>
+        <pre class="idl">
+          dictionary SemanticType {
+            DOMString name;
+            USVString context;
+          };
         </pre>
         <p>
-          The <a>ThingActionInit</a> dictionary describes the arguments and the return value.
+          Represents a semantic type annotation, containing a name and a context.
           <ul>
-            <li>The <dfn>name</dfn> attribute provides the action name.</li>
-            <li>The <dfn>action</dfn> attribute provides a function that defines the action.</li>
-            <li>The <dfn>inputDataDescription</dfn> attribute provides the description of the input arguments.</li>
-            <li>The <dfn>outputDataDescription</dfn> attribute provides the description of the returned data.</li>
-            <li>
-                The <dfn>semanticTypes</dfn> attribute provides a list of semantic type annotations (e.g. labels, classifications etc) relevant to the action, represented as <a>SemanticType</a> dictionaries.
-            </li>
+            <li>The <dfn>name</dfn> attribute represents the name of the semantic type in the given context.</li>
+            <li>The <dfn>context</dfn> attribute represents an URL link to the context of the semantic classification.</li>
           </ul>
         </p>
-        </section>
-      </section> <!-- addAction -->
-
-      <section> <h3>The <dfn>removeAction()</dfn> method</h3>
-        <p>
-          Removes the action specified by the <code>name</code> argument, updates the <a>Thing Description</a> and returns the object.
+        <p class="ednote">
+          Semantic type examples to be added.
         </p>
       </section>
+    </section> <!-- addProperty() -->
 
-      <section> <h3>The <dfn>addEvent()</dfn> method</h3>
-        <p>
-          Adds an event to the <a>Thing</a> object as defined by the <code>event</code> argument of type <a>ThingEventInit</a> and updates the <a>Thing Description</a>.
-        </p>
-        <section data-dfn-for="ThingEventInit">
-          <h4>The <dfn>ThingEventInit</dfn> dictionary</h4>
-          <pre class="idl">
-            dictionary ThingEventInit {
-              DOMString name;
-              sequence&lt;SemanticType&gt; semanticTypes;
-              ThingDescription dataDescription;
-            };
-          </pre>
-          <ul>
-            <li>The <dfn>name</dfn> attribute represents the event name.</li>
-            <li>The <dfn>semanticTypes</dfn> attribute represent a list of semantic type annotations attached to the event.</li>
-            <li>The <dfn>dataDescription</dfn> attribute represents the description of the data that is attached to the event.</li>
-          </ul>
-        </section>
+    <section> <h3>The <dfn>removeProperty()</dfn> method</h3>
+      <p>
+        Removes the property specified by the <code>name</code> argument, updates the <a>Thing Description</a> and returns the object.
+      </p>
+    </section>
+
+    <section> <h3>The <dfn>addAction()</dfn> method</h3>
+      <p>
+        Adds an action to the <a>Thing</a> object as defined by the <code>action</code> argument of type <a>ThingActionInit</a> and updates the <a>Thing Description</a>.
+      </p>
+      <section data-dfn-for="ThingActionInit">
+        <h4>The <dfn>ThingActionInit</dfn> dictionary</h4>
+        <pre class="idl">
+          dictionary ThingActionInit {
+            DOMString name;
+            ThingDescription inputDataDescription;
+            ThingDescription outputDataDescription;
+            sequence&lt;SemanticType&gt; semanticTypes;
+            Function action;
+          };
+      </pre>
+      <p>
+        The <a>ThingActionInit</a> dictionary describes the arguments and the return value.
+        <ul>
+          <li>The <dfn>name</dfn> attribute provides the action name.</li>
+          <li>The <dfn>action</dfn> attribute provides a function that defines the action.</li>
+          <li>The <dfn>inputDataDescription</dfn> attribute provides the description of the input arguments.</li>
+          <li>The <dfn>outputDataDescription</dfn> attribute provides the description of the returned data.</li>
+          <li>
+              The <dfn>semanticTypes</dfn> attribute provides a list of semantic type annotations (e.g. labels, classifications etc) relevant to the action, represented as <a>SemanticType</a> dictionaries.
+          </li>
+        </ul>
+      </p>
       </section>
+    </section> <!-- addAction -->
 
-      <section> <h3>The <dfn>removeEvent()</dfn> method</h3>
-        <p>
-          Removes the event specified by the <code>name</code> argument, updates the <a>Thing Description</a> and returns the object.
-        </p>
+    <section> <h3>The <dfn>removeAction()</dfn> method</h3>
+      <p>
+        Removes the action specified by the <code>name</code> argument, updates the <a>Thing Description</a> and returns the object.
+      </p>
+    </section>
+
+    <section> <h3>The <dfn>addEvent()</dfn> method</h3>
+      <p>
+        Adds an event to the <a>Thing</a> object as defined by the <code>event</code> argument of type <a>ThingEventInit</a> and updates the <a>Thing Description</a>.
+      </p>
+      <section data-dfn-for="ThingEventInit">
+        <h4>The <dfn>ThingEventInit</dfn> dictionary</h4>
+        <pre class="idl">
+          dictionary ThingEventInit {
+            DOMString name;
+            sequence&lt;SemanticType&gt; semanticTypes;
+            ThingDescription dataDescription;
+          };
+        </pre>
+        <ul>
+          <li>The <dfn>name</dfn> attribute represents the event name.</li>
+          <li>The <dfn>semanticTypes</dfn> attribute represent a list of semantic type annotations attached to the event.</li>
+          <li>The <dfn>dataDescription</dfn> attribute represents the description of the data that is attached to the event.</li>
+        </ul>
       </section>
+    </section>
 
-      <section> <h3>The <dfn>onRetrieveProperty()</dfn> method</h3>
-        <p>
-          Registers the handler function for property retrieve requests received for the <a>Thing</a>, as defined by the <code>handler</code> property of type <code><a>RequestHandler</a></code>. The handler will receive an argument <var>request</var> of type <code><a>Request</a></code> where at least <var>request.name</var> is defined and represents the name of the property to be retrieved.
-        </p>
-      </section>
+    <section> <h3>The <dfn>removeEvent()</dfn> method</h3>
+      <p>
+        Removes the event specified by the <code>name</code> argument, updates the <a>Thing Description</a> and returns the object.
+      </p>
+    </section>
 
-      <section> <h3>The <dfn>onUpdateProperty()</dfn> method</h3>
-        <p>
-          Defines the handler function for property update requests received for the <a>Thing</a>, as defined by the <code>handler</code> property of type <code><a>RequestHandler</a></code>. The handler will receive an argument <var>request</var> of type <code><a>Request</a></code> where <var>request.name</var> defines the name of the property to be retrieved and <var>request.data</var> defines the new value of the property.
-        </p>
-      </section>
+    <section> <h3>The <dfn>onRetrieveProperty()</dfn> method</h3>
+      <p>
+        Registers the handler function for property retrieve requests received for the <a>Thing</a>, as defined by the <code>handler</code> property of type <code><a>RequestHandler</a></code>. The handler will receive an argument <var>request</var> of type <code><a>Request</a></code> where at least <var>request.name</var> is defined and represents the name of the property to be retrieved.
+      </p>
+    </section>
 
-      <section> <h3>The <dfn>onInvokeAction()</dfn> method</h3>
-        <p>
-          Defines the handler function for action invocation requests received for the <a>Thing</a>, as defined by the <code>handler</code> property of type <code><a>RequestHandler</a></code>.  The handler will receive an argument <var>request</var> of type <code><a>Request</a></code> where <var>request.name</var> defines the name of the action to be invoked and <var>request.data</var> defines the input arguments for the action as defined by the <a>Thing Description</a>.
-        </p>
-      </section>
+    <section> <h3>The <dfn>onUpdateProperty()</dfn> method</h3>
+      <p>
+        Defines the handler function for property update requests received for the <a>Thing</a>, as defined by the <code>handler</code> property of type <code><a>RequestHandler</a></code>. The handler will receive an argument <var>request</var> of type <code><a>Request</a></code> where <var>request.name</var> defines the name of the property to be retrieved and <var>request.data</var> defines the new value of the property.
+      </p>
+    </section>
 
-      <section> <h3>The <dfn>onObserve()</dfn> method</h3>
-        <p>
-          Defines the handler function for observe requests received for the <a>Thing</a>, as defined by the <code>handler</code> property of type <code><a>RequestHandler</a></code>. The handler will receive an argument <var>request</var> of type <code><a>Request</a></code> where
-          <ul>
-            <li>
-              <var>request.name</var> defines the name of the property or action or event to be observed.
-            </li>
-            <li>
-              <var>request.options.observeType</var> is of type <a>RequestType</a> and defines whether a property change or action invocation or event emitting is observed, or the changes to the <a>Thing Description </a> are observed.
-            </li>
-            <li>
-              <var>request.options.subscribe</var> is <code>true</code> if subscription is turned or kept being turned on, and it is <code>false</code> when subscription is turned off.
-            </li>
-          </ul>
-        </p>
-      </section> <!-- onObserve() -->
+    <section> <h3>The <dfn>onInvokeAction()</dfn> method</h3>
+      <p>
+        Defines the handler function for action invocation requests received for the <a>Thing</a>, as defined by the <code>handler</code> property of type <code><a>RequestHandler</a></code>.  The handler will receive an argument <var>request</var> of type <code><a>Request</a></code> where <var>request.name</var> defines the name of the action to be invoked and <var>request.data</var> defines the input arguments for the action as defined by the <a>Thing Description</a>.
+      </p>
+    </section>
 
-      <section> <h3>The <dfn>register()</dfn> method</h3>
-        <p>
-          Generates the <a>Thing Description</a> given the properties, actions and events defined for this object. If a <code>directory</code> argument is given, make a request to register the <a>Thing Description</a> with the given WoT repository by invoking its <code>register</code> action.
-        </p>
-      </section>
+    <section> <h3>The <dfn>onObserve()</dfn> method</h3>
+      <p>
+        Defines the handler function for observe requests received for the <a>Thing</a>, as defined by the <code>handler</code> property of type <code><a>RequestHandler</a></code>. The handler will receive an argument <var>request</var> of type <code><a>Request</a></code> where
+        <ul>
+          <li>
+            <var>request.name</var> defines the name of the property or action or event to be observed.
+          </li>
+          <li>
+            <var>request.options.observeType</var> is of type <a>RequestType</a> and defines whether a property change or action invocation or event emitting is observed, or the changes to the <a>Thing Description </a> are observed.
+          </li>
+          <li>
+            <var>request.options.subscribe</var> is <code>true</code> if subscription is turned or kept being turned on, and it is <code>false</code> when subscription is turned off.
+          </li>
+        </ul>
+      </p>
+    </section> <!-- onObserve() -->
 
-      <section> <h3>The <dfn>unregister()</dfn> method</h3>
-        <p>
-          If a <code>directory</code> argument is given, make a request to unregister the <a>Thing Description</a> with the given WoT repository by invoking its <code>unregister</code> action. Then, and in the case no arguments were provided to this function, stop the <a>Thing</a> and remove the <a>Thing Description</a>.
-        </p>
-      </section>
+    <section> <h3>The <dfn>register()</dfn> method</h3>
+      <p>
+        Generates the <a>Thing Description</a> given the properties, actions and events defined for this object. If a <code>directory</code> argument is given, make a request to register the <a>Thing Description</a> with the given WoT repository by invoking its <code>register</code> action.
+      </p>
+    </section>
 
-      <section> <h3>The <dfn>start()</dfn> method</h3>
-        <p>
-          Start serving external requests for the <a>Thing</a>.
-        </p>
-      </section>
+    <section> <h3>The <dfn>unregister()</dfn> method</h3>
+      <p>
+        If a <code>directory</code> argument is given, make a request to unregister the <a>Thing Description</a> with the given WoT repository by invoking its <code>unregister</code> action. Then, and in the case no arguments were provided to this function, stop the <a>Thing</a> and remove the <a>Thing Description</a>.
+      </p>
+    </section>
 
-      <section> <h3>The <dfn>stop()</dfn> method</h3>
-        <p>
-          Stop serving external requests for the <a>Thing</a>.
-        </p>
-      </section>
+    <section> <h3>The <dfn>start()</dfn> method</h3>
+      <p>
+        Start serving external requests for the <a>Thing</a>.
+      </p>
+    </section>
 
-      <section> <h3>The <dfn>emitEvent()</dfn> method</h3>
-        <p>
-          Emits an the event initialized with the event name specified by the <code>eventName</code> argument and data specified by the <code>payload</code> argument.
-        </p>
-      </section>
+    <section> <h3>The <dfn>stop()</dfn> method</h3>
+      <p>
+        Stop serving external requests for the <a>Thing</a>.
+      </p>
+    </section>
 
-      <section data-dfn-for="ExposedThing-Events">
-        <h2>Events supported by ExposedThing</h2>
-        <p>
-          The following default events SHOULD be supported by <a>ExposedThing</a> implementations:
-          <ul>
-            <li>"<dfn>propertychange</dfn>" of type <a>PropertyChangeEvent</a></li>
-            <li>"<dfn>actioninvocation</dfn>" of type <a>ActionInvocationEvent</a></li>
-            <li>"<dfn>descriptionchange</dfn>" of type <a>ThingDescriptionChangeEvent</a>.</li>
-          </ul>
-        </p>
-        <p>
-          In addition, user defined events are specified by the <a>Thing Description</a>.
-        </p>
-      </section> <!-- Events -->
-    </section> <!-- ExposedThing -->
+    <section> <h3>The <dfn>emitEvent()</dfn> method</h3>
+      <p>
+        Emits an the event initialized with the event name specified by the <code>eventName</code> argument and data specified by the <code>payload</code> argument.
+      </p>
+    </section>
+
+    <section data-dfn-for="ExposedThing-Events">
+      <h2>Events supported by ExposedThing</h2>
+      <p>
+        The following default events SHOULD be supported by <a>ExposedThing</a> implementations:
+        <ul>
+          <li>"<dfn>propertychange</dfn>" of type <a>PropertyChangeEvent</a></li>
+          <li>"<dfn>actioninvocation</dfn>" of type <a>ActionInvocationEvent</a></li>
+          <li>"<dfn>descriptionchange</dfn>" of type <a>ThingDescriptionChangeEvent</a>.</li>
+        </ul>
+      </p>
+      <p>
+        In addition, user defined events are specified by the <a>Thing Description</a>.
+      </p>
+    </section> <!-- Events -->
 
     <section>
       <h2>Examples</h2>
@@ -994,7 +991,7 @@
           });
       </pre>
     </section> <!-- ExposedThing Examples -->
-  </section> <!-- The Thing Server API -->
+  </section> <!-- ExposedThing -->
 
   <section> <h2 id="security">Security and Privacy</h2>
     <p>
@@ -1006,7 +1003,7 @@
 
   <section> <h2>Terminology and conventions</h2>
     <p>
-      The generic WoT terminology is defined in [[!WOT-ARCHITECTURE]]: <dfn data-lt="Things">Thing</dfn>, <dfn data-lt="Thing Descriptions">Thing Description</dfn> (in short <dfn>TD</dfn>), <dfn>Web of Things</dfn> (in short <b><i>WoT</i></b>),  <dfn>WoT Interface</dfn>, <dfn>Protocol Bindings</dfn>, <dfn>WoT Runtime</dfn>, <dfn data-lt="consume|consume a TD|consuming a TD">Consuming a Thing Description</dfn>, <dfn>Things Directory</dfn> etc.
+      The generic WoT terminology is defined in [[!WOT-ARCHITECTURE]]: <dfn data-lt="Things">Thing</dfn>, <dfn data-lt="Thing Descriptions">Thing Description</dfn> (in short <dfn>TD</dfn>), <dfn>Web of Things</dfn> (in short <b><i>WoT</i></b>),  <dfn>WoT Interface</dfn>, <dfn>Protocol Bindings</dfn>, <dfn>WoT Runtime</dfn>, <dfn data-lt="consume|consume a TD|consuming a TD">Consuming a Thing Description</dfn>, <dfn>Thing Directory</dfn> etc.
     </p>
     <p class="note">
       In this version of the specification, a <a>WoT Runtime</a> is assumed to run scripts that uses this API to define one or more <a>Thing</a>s that share a common event loop. Script deployment methods are out of scope of this version. In future versions, running multiple scripts (as modules) may be possible, and script deployment MAY be implemented using a manager <a>Thing</a> whose actions permit script lifecycle management operations.


### PR DESCRIPTION
- Rename `WoT.retrieve()` to `consume()` and `createLocalThing()` to `expose()`.
- Remove the Client API and Server API as sections and just mention ConsumedThing is client API and ExposedThing is server API.
- Replace general nouns property action and event to defined/linked terms for WoT Property, Action and Event.
