### PR TITLE
update security section editor's note

### DIFF
--- a/index.html
+++ b/index.html
@@ -1130,12 +1130,16 @@
     </section> <!-- ExposedThing Examples -->
   </section> <!-- The Thing Server API -->
 
-  <section> <h2 id="security">Security and Privacy</h2>
-    <p>
-      The trust model, attacker model, threat model and possible mitigation
-      proposals for WoT in general, and the Scripting API in particular are presented in the [WoT Security and Privacy](https://github.com/w3c/wot/tree/master/security-privacy) documents and the [WoT Architecture](https://w3c.github.io/wot-architecture/) documents [Security Considerations](https://w3c.github.io/wot-architecture/#security-considerations) section.
-    </p>
-    <p class="ednote">The security section will be completed later.</p>
+  <section> <h2 id="security">Security and Privacy Considerations</h2>
+  <p class="ednote">
+  Please see the
+  <a href="https://github.com/w3c/wot-security/">WoT Security and Privacy</a>
+  repository for work in progress regarding threat models, assets, risks,
+  recommended mitigations, and best practices for security and privacy for systems
+  using the Web of Things.
+  Once complete, security and privacy considerations relevant to the Scripting API will
+  be summarized in this section.
+</p>
   </section>
 
   <section class="appendix" id="Changes"><h2>Changes</h2>


### PR DESCRIPTION
Replace (broken, incomplete) security section with simple pointer to wot-security repo.  For some reason I can't merge and can't fetch the current state of the repo to resolve conflicts, however, so this PR will have to be merged manually.