### PR TITLE
Use singular for field names (LD convention)

### DIFF
--- a/index.html
+++ b/index.html
@@ -367,7 +367,7 @@
       </p>
       <pre class="idl">
         dictionary SemanticAnnotations {
-            sequence&lt;SemanticType&gt; semanticTypes;
+            sequence&lt;SemanticType&gt; semanticType;
             sequence&lt;SemanticMetadata&gt; metadata;
         };
       </pre>

--- a/index.html
+++ b/index.html
@@ -372,7 +372,7 @@
         };
       </pre>
       <p>
-        The <dfn>semanticTypes</dfn> property denotes a list of <a>SemanticType</a> objects that define the semantic types that can be used in semantic metadata type-value pairs.
+        The <dfn>semanticType</dfn> property denotes a list of <a>SemanticType</a> objects that define the semantic types that can be used in semantic metadata type-value pairs.
       </p>
       <p>
         The <dfn>metadata</dfn> property denotes a list of <a>SemanticMetadata</a> objects (type-value pairs).


### PR DESCRIPTION
The field `semanticTypes` of SemanticAnnotations should be `semanticType`.