### PR TITLE
Fix #163

### DIFF
--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -383,13 +383,13 @@ export interface StringSchema extends BaseSchema {
 
 export interface ObjectSchema extends BaseSchema {
     type: "object";
-    properties: { [key: string]: DataSchema };
+    properties?: { [key: string]: DataSchema };
     required?: Array<string>;
 }
 
 export interface ArraySchema extends BaseSchema {
     type: "array";
-    items: DataSchema;
+    items?: DataSchema;
     minItems?: number;
     maxItems?: number;
 }


### PR DESCRIPTION
Change to the typescript definitions to make "items" in ArraySchema and "properties" in ObjectSchema non mandatory (as described by the TD spec).