### PR TITLE
Add InteractionData

### DIFF
--- a/index.html
+++ b/index.html
@@ -589,13 +589,19 @@
     <section>
       <h3>The <dfn>readProperty()</dfn> method</h3>
       <div>
-        Reads a <a>Property</a> value. Takes a string argument |propertyName| and and an optional {{InteractionOptions}} |options:InteractionOptions| argument. It returns a <a>Property</a> value represented as `any` type. The method MUST run the following steps:
+        Reads a <a>Property</a> value. Takes a string argument |propertyName|
+        and an optional {{InteractionOptions}} |options:InteractionOptions|
+        argument. It returns a <a>Property</a> value represented as `any` type.
+        The method MUST run the following steps:
         <ol>
           <li>
-            Return a {{Promise}} |promise:Promise| and execute the next steps <a>in parallel</a>.
+            Return a {{Promise}} |promise:Promise| and execute the next steps
+            <a>in parallel</a>.
           </li>
           <li>
-            If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
+            If invoking this method is not allowed for the current scripting
+            context for security reasons, reject |promise| with a
+            {{SecurityError}} and abort these steps.
           </li>
           <li>
             Let |interaction| be the value of ||td||'s |properties|'s
@@ -608,10 +614,14 @@
             |interaction|'s |forms| whose |op| is `readproperty`.
           </li>
           <li>
-            If |form| is failure, reject |promise| with a {{SyntaxError}} and abort these steps.
+            If |form| is failure, reject |promise| with a {{SyntaxError}} and
+            abort these steps.
           </li>
           <li>
-            Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to retrieve the value of the <a>Property</a>given by |propertyName| using |form| and the optional URI templates given in |options|' {{uriVariables}}.
+            Make a request to the underlying platform (via the
+            <a>Protocol Bindings</a>) to retrieve the value of the <a>Property</a>
+            given by |propertyName| using |form| and the optional URI templates
+            given in |options|' {{uriVariables}}.
           </li>
           <li>
             If the request fails, reject |promise| with the error received from the <a>Protocol Bindings</a> and abort these steps.
@@ -666,12 +676,12 @@
                 Let |value| be the value of |result|'s |key|.
               </li>
               <li>
-                Let |dataschema| be the value of ||td||'s |properties|'s |key|.
+                Let |schema| be the value of ||td||'s |properties|'s |key|.
               </li>
               <li>
                 Let |property| be the result of running
                 <a>parse interaction response</a> on |value|, |form| and
-                |dataschema|.
+                |schema|.
               </li>
             </ol>
           </li>
@@ -723,12 +733,12 @@
                 Let |value| be the value of |result|'s |key|.
               </li>
               <li>
-                Let |dataschema| be the value of ||td||'s |properties|'s |key|.
+                Let |schema| be the value of ||td||'s |properties|'s |key|.
               </li>
               <li>
                 Let |property| be the result of running
                 <a>parse interaction response</a> on |value|, |form| and
-                |dataschema|.
+                |schema|.
               </li>
             </ol>
           </li>
@@ -820,14 +830,14 @@
             `null`.
           </li>
           <li>
-            Let |dataschemas:object| be an object and for each string |name:string|
+            Let |schemas:object| be an object and for each string |name:string|
             in |propertyNames| add a property with key |name| and let its value
             be the value of ||td||'s |properties|'s |name|.
           </li>
           <li>
             For each key |key:string| in |properties|, take its value as |value|
             and run the <a>create interaction data</a> steps on |value|, |form|
-            and the value for |dataschema|'s |key|.
+            and the value for |schema|'s |key|.
             If that fails for any |name|, reject <a>promise</a> with a
             {{SyntaxError}} and abort these steps.
           </li>
@@ -942,8 +952,7 @@
             If |form| is failure, reject |promise| with a {{SyntaxError}} and abort these steps.
           </li>
           <li>
-            Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to stop observing the <a>Property</a> identified by |propertyName|, with |form| and optional URI templates given in |options|'
-            {{uriVariables}}.
+            Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to stop observing the <a>Property</a> identified by |propertyName|, with |form| and optional URI templates given in |options|' {{uriVariables}}.
           </li>
           <li>
             If the request fails, reject |promise| with the error received from the <a>Protocol Bindings</a> and abort these steps.
@@ -1157,116 +1166,180 @@
       Form</a> contains a `contentType` to describe the data.
       For certain content types, a <a>DataSchema</a> is defined, based on
       <a>JSON schema</a>, making possible to represent these contents as
-      JavaScript types.
+      JavaScript types and eventually set range constraints on the data.
     </p>
     <p>
-      This interface provides automatic value parsing when a <a>DataSchema</a>
-      is available, and otherwise provide a way to parse data based on
-      content type and exposed as a stream.
+      This interface exposes the data returned from the <a>WoT Interaction</a>.
     </p>
     <pre class="idl">
       [SecureContext, Exposed=(Window,Worker)]
       interface InteractionData {
-        readonly attribute any value;
         readonly attribute ReadableStream? data;
-        readonly attribute DataSchema? dataSchema;
+        readonly attribute boolean dataUsed;
         readonly attribute Form? form;
+        readonly attribute DataSchema? schema;
+        Promise&lt;ArrayBuffer&gt; arrayBuffer();
+        Promise&lt;any&gt; value();
       };
     </pre>
     <p>
-      The <dfn>value</dfn> property represents the parsed payload in
-      <a>WoT Interactions</a>.
-    </p>
-    <p>
       The <dfn>data</dfn> property represents the raw payload in
-      <a>WoT Interactions</a> as a {{ReadableStream}}.
+      <a>WoT Interactions</a> as a {{ReadableStream}}, initialy `null`.
     </p>
     <p>
-      The <dfn>dataSchema</dfn> attribute represents the <a>DataSchema</a>
-      of the payload as a {{JSON}} object.
+      The <dfn>dataUsed</dfn> property tells whether the <a>data</a> stream has
+      been <a href="https://fetch.spec.whatwg.org/#concept-readablestream-disturbed">
+      disturbed</a>. Initially `false`.
     </p>
     <p>
       The <dfn>form</dfn> attribute represents the <a>Form</a> selected from
-      the <a>Thing Description</a> for this <a>WoT Interaction</a>.
+      the <a>Thing Description</a> for this <a>WoT Interaction</a>,
+      initially `null`.
+    </p>
+    <p>
+      The <dfn>schema</dfn> attribute represents the <a>DataSchema</a>
+      of the payload as a {{JSON}} object, initially `null`.
+    </p>
+    <p>
+      The <dfn>[[\value]]</dfn> internal slot represents the parsed value of
+      the <a>WoT Interaction</a>, initially `undefined` (note that `null` is a
+      valid value).
     </p>
 
-    <section><h3>The <dfn>parse interaction response</dfn> algorithm</h3>
-      For a given <a>ConsumedThing</a> object |thing:ConsumedThing|, in order to
-      <a>parse interaction response</a> given |response|, |form:Form| and
-      |dataschema:object|, run these steps:
+    <section><h3>The  <dfn>arrayBuffer()</dfn> function</h3>
+      When invoked, MUST run the following steps:
       <ol>
         <li>
-          Let |result| be a new {{InteractionData}} object.
+          Return a {{Promise}} |promise:Promise| and execute the next steps
+          <a>in parallel</a>.
         </li>
         <li>
-          Let |result|'s |dataSchema| be |dataschema|.
+          If |data| is not {{ReadableStream}} or if |dataUsed| is `true`,
+          reject|promise| with {{SyntaxError}} and abort these steps.
         </li>
         <li>
-          Let |result|'s |form| be |form|.
+          Let |reader| be the result of
+          <a href="https://fetch.spec.whatwg.org/#concept-get-reader">
+          getting a reader</a> from |data|. If that threw an exception, reject
+          |promise| with that exception and abort these steps.
         </li>
         <li>
-          Let |result|'s |data| be a new {{ReadableStream}} representation of
-          the payload data |response|.
+          Let |bytes| be the result of <a href=
+          "https://fetch.spec.whatwg.org/#concept-read-all-bytes-from-readablestream">
+          reading all bytes</a> from |data| with |reader|.
         </li>
         <li>
-          Let |rawData| be the bytes representation of the payload data |response|.
+          Set |dataUsed| to `true`.
         </li>
         <li>
-          Let |value| be `undefined`.
+          Let |arrayBuffer| be a new {{ArrayBuffer}} whose contents are |bytes|.
+          If that throws, reject |promise| with that exception and abort these steps.
         </li>
         <li>
-          If |dataschema|'s |type| is defined, let |result|'s |value| be the
-          result of running the <a>parse data schema</a> sub-steps on
-          |rawData|, |form| and |dataschema|.
-          If that throws, let |result|'s |value| be `undefined`.
-        </li>
-        <li>
-          Return |result| and abort these steps.
+          Resolve |promise| with |arrayBuffer|.
         </li>
       </ol>
-      To run the <dfn>parse data schema</dfn> steps on |rawData|, |form| and
-      |dataschema|:
+    </section>
+
+    <section><h3>The <dfn>value()</dfn> function</h3>
+      Parses the data returned from the <a>WoT Interaction</a> and returns a
+      value with the type described by the <a>DataSchema</a> of the interaction
+      if that exists, or by the `contentType` of the <a>Form</a> used for the
+      interaction. The method MUST run the following steps:
       <ol>
         <li>
-          Let |type| be |dataschema|'s |type|.
+          Return a {{Promise}} |promise:Promise| and execute the next steps
+          <a>in parallel</a>.
         </li>
         <li>
-          If |type| is `"null"`, return `null`.
+          If the value of the <a>[[\value]]</a> <a>internal slot</a> is not
+          `undefined`, resolve |promise| with that value and abort these steps.
         </li>
         <li>
-          If |type| is `"boolean"` and |rawData| is a falsy value, return
-          `false`, otherwise return `true`.
+          If the value of the |data| property is not a {{ReadableStream}} or if
+          |dataUsed| is `true`, or if |form| is `null` or if |schema| or its
+          |type| are `null` or `undefined`,
+          reject |promise| with {{SyntaxError}} and abort these steps.
         </li>
         <li>
-          If |type| is `"integer"` or `"number"`, let |value| be the number
-          parsed from |rawData|; if |form|'s |minimum| is defined and
-          |result| is smaller, or if |form|'s |maximum| is defined and
-          |result| is bigger, throw {{SyntaxError}} and abort these steps;
+          Let |reader| be the result of
+          <a href="https://fetch.spec.whatwg.org/#concept-get-reader">
+          getting a reader</a> from |data|. If that threw an exception, reject
+          |promise| with that exception and abort these steps.
         </li>
         <li>
-          If |type| is `"string"`, let |value| be the string parsed from
-          |rawData| using |form|'s |contentType| and |contentCoding|.
+          Let |bytes| be the result of <a href=
+          "https://fetch.spec.whatwg.org/#concept-read-all-bytes-from-readablestream">
+          reading all bytes</a> from |data| with |reader|.
+        </li>
+        <li>
+          Set |dataUsed| to `true`.
+        </li>
+        <li>
+          If |form|'s |contentType| is not `application/json` and if a mapping is
+          available in the <a>Protocol Bindings</a> from |form|'s |contentType|
+          to [JSON-SCHEMA], transform |bytes| with that mapping.
+        </li>
+        <li>
+          Let |json| be the result of running <a>parse JSON from bytes</a> on
+          |bytes|. If that throws, reject |promise| with {{SyntaxError}} and
+          abort these steps.
+        </li>
+        <li>
+          Set <a>[[\value]]</a> to the result of running <a>check data schema</a>
+          on |json| and |schema|. If that throws, reject |promise| with that
+          exception and abort these steps.
+        </li>
+        <li>
+          Resolve |promise| with <a>[[\value]]</a>.
+        </li>
+      </ol>
+    </section>
+
+    <section><h3>The <dfn>check data schema</dfn> algorithm</h3>
+      To run the <a>check data schema</a> steps on |payload| and |schema:object|,
+      <ol>
+        <li>
+          Let |type| be |schema|'s |type|.
+        </li>
+        <li>
+          If |type| is `"null"` and if |payload| is not `null`,
+          throw {{SyntaxError}} and abort these steps, otherwise return `null`.
+        </li>
+        <li>
+          If |type| is `"boolean"` and |payload| is a falsey value or its byte
+          length is 0, return `false`, otherwise return `true`.
+        </li>
+        <li>
+          If |type| is `"integer"` or `"number"`,
+          <ol>
+            <li>
+              If |payload| is not a number, throw {{SyntaxError}} and abort these steps.
+            </li>
+            <li>
+              If |form|'s |minimum| is defined and |payload| is smaller, or if |form|'s |maximum| is defined and |payload| is bigger, throw {{SyntaxError}} and abort these steps.
+            </li>
+          </ol>
+        </li>
+        <li>
+          If |type| is `"string"`, return |payload|.
         </li>
         <li>
           If |type| is `"array"`, run these sub-steps:
           <ol>
             <li>
-              Let |length| be the length of |form|'s |items| array.
+              If |payload| is not an array, throw {{SyntaxError}} and abort these steps.
             </li>
             <li>
-              If |form|'s |minItems| is defined and |length| is less than
-              that, or if |form|'s |maxItems| is defined and |length| is
-              more than that, throw {{SyntaxError}} and abort these steps.
+              If |form|'s |minItems| is defined and |payload|'s |length| is
+              less than that, or if |form|'s |maxItems| is defined and |payload|'s
+              |length| is more than that, throw {{SyntaxError}} and abort these steps.
             </li>
             <li>
-              Split |rawData| in |length| number of equal chunks. If that fails,
-              throw {{SyntaxError}} and abort these steps.
-            </li>
-            <li>
-              Let |value| be an array of items obtained by
-              running these steps on each |rawData| chunk and the |item| in
-              |form|'s |items| of the same index. If this throws at any stage,
-              throw {{SyntaxError}} and abort these steps.
+              Let |payload| be an array of items obtained by running the
+              <a>check data schema</a> steps on each element |item| of |payload|
+              and |schema|'s |items|.
+              If this throws at any stage, throw {{SyntaxError}} and abort these steps.
             </li>
           </ol>
         </li>
@@ -1274,88 +1347,86 @@
           If |type| is `"object"`, run these sub-steps:
           <ol>
             <li>
-              If |dataschema|'s |properties| is not an object,
+              If |payload| or |schema|'s |properties| is not an object,
               throw {{SyntaxError}} and abort these steps.
             </li>
             <li>
-              Let |value| be the result of running
-              <a>parse JSON from bytes</a> on |rawData|.
-            </li>
-            <li>
-              For each property |key| in |value|,
+              For each property |key| in |payload|,
               <ol>
                 <li>Let |prop| be the value of |key|.</li>
                 <li>
-                  Let |schema| be the value of |key| in |interaction|'s
+                  Let |propSchema| be the value of |key| in |interaction|'s
                   |properties|.
                 </li>
                 <li>
                   Let |prop| be the result of running the
-                  <a>parse data schema</a> steps on |prop|, |form| and |schema|.
+                  <a>check data schema</a> steps on |prop| and |propSchema|.
                   If this throws, then throw {{SyntaxError}} and abort these steps.
                 </li>
               </ol>
             </li>
             <li>
-              Let |required| be |dataschema|'s |required| if that is an array
+              Let |required| be |schema|'s |required| if that is an array
               or an empty array otherwise.
             </li>
             <li>
-              For each |key| in |required|, if |key| is not present in |value|,
+              For each |key| in |required|, if |key| is not present in |payload|,
               throw {{SyntaxError}} and abort these steps.
             </li>
-            <li>
-              Return |value|.
-            </li>
           </ol>
+        </li>
+        <li>
+          Return |payload|.
         </li>
       </ol>
     </section>
 
     <section><h3>The <dfn>create interaction data</dfn> algorithm</h3>
       For a given <a>ConsumedThing</a> object |thing:ConsumedThing|, in order to
-      <a>create interaction data</a> given |value|, |form:Form| and
-      |dataschema:object|, run these steps:
+      <a>create interaction data</a> given |source|, |form:Form| and
+      |schema:object|, run these steps:
       <ol>
         <li>
-          If |value| is an {{InteractionData}} object whose |data| is a
-          {{ReadableStream}}, return |value| and abort these steps.
+          If |source| is an {{InteractionData}} object whose |data| is a
+          {{ReadableStream}}, set its |form| to |form|,
+          return |source| and abort these steps.
         </li>
         <li>
-          Let |data| be a new an {{InteractionData}} object whose |value| is
-          `undefined`, whose |form| is |form|, whose |dataSchema| is |dataschema|
-          and whose |data| is `null`.
+          Let |idata| be a new an {{InteractionData}} object whose [[\value]]
+          <a>internal slot</a> is `undefined`, whose |form| is |form|,
+          whose |schema| is set to |schema| and whose |data| is `null`.
         </li>
         <li>
-          If |dataschema|'s |type| is defined, run these sub-steps:
+          If |schema|'s |type| is defined, run these sub-steps:
           <ol>
             <li>
-              If |type| is `"null"` and |value| is not,
+              If |type| is `"null"` and |source| is not,
               throw {{SyntaxError}} and abort these steps.
             </li>
             <li>
-              If |type| is `"boolean"` and |value| is a falsy value, let
-              |value| be `false`, otherwise `true`.
+              If |type| is `"boolean"` and |source| is a falsy value, set
+              |idata|'s [[\value]] |value| to `false`, otherwise to `true`.
             </li>
             <li>
-              If |type| is `"integer"` or `"number"` and |value| is not a number,
-              or if |form|'s |minimum| is defined and |value| is smaller,
-              or if |form|'s |maximum| is defined and |value| is bigger,
+              If |type| is `"integer"` or `"number"` and |source| is not a number,
+              or if |form|'s |minimum| is defined and |source| is smaller,
+              or if |form|'s |maximum| is defined and |source| is bigger,
               throw {{SyntaxError}} and abort these steps.
             </li>
             <li>
-              If |type| is `"string"` and |value| is not a string, let |value| be
-              the result of running <a>serialize JSON to bytes</a> on |value|.
+              If |type| is `"string"` and |source| is not a string, let |idata|'s
+              [[\value]] be the result of running <a>serialize JSON to bytes</a>
+              on |source|.
               If that is failure, throw {{SyntaxError}} and abort these steps.
             </li>
             <li>
               If |type| is `"array"`, run these sub-steps:
               <ol>
                 <li>
-                  If |value| is not an array, throw {{SyntaxError}} and abort these steps.
+                  If |source| is not an array, throw {{SyntaxError}} and abort these steps.
                 </li>
                 <li>
-                  Let |length| be the length of |value|.
+                  Let |length| be the length of |source|.
                 </li>
                 <li>
                   If |form|'s |minItems| is defined and |length| is less than
@@ -1363,11 +1434,14 @@
                   more than that, throw {{SyntaxError}} and abort these steps.
                 </li>
                 <li>
-                  For each |item| in |value| with |index|, let |schema| be
-                  |dataschema|'s |items| at |index| and let |item| be the
-                  result of running these steps on |item|, |form| and |schema|.
-                  If this throws at any stage,
-                  throw {{SyntaxError}} and abort these steps.
+                  For each |item| in |source|, let |itemschema| be |schema|'s
+                  |items| and let |item| be the result of running the
+                  <a>create interaction data</a> steps on |item|, |form| and
+                  |itemschema|.
+                  If this throws, throw {{SyntaxError}} and abort these steps.
+                </li>
+                <li>
+                  Set |data|'s [[\value]] to |source|.
                 </li>
               </ol>
             </li>
@@ -1375,39 +1449,78 @@
               If |type| is `"object"`, run these sub-steps:
               <ol>
                 <li>
-                  If |value| is not an object, throw {{SyntaxError}} and abort these steps.
+                  If |source| is not an object, throw {{SyntaxError}} and abort these steps.
                 </li>
                 <li>
-                  If |dataschema|'s |properties| is not an object,
+                  If |schema|'s |properties| is not an object,
                   throw {{SyntaxError}} and abort these steps.
                 </li>
                 <li>
-                  For each property |key| in |value|,
+                  For each property |key| in |source|,
                   <ol>
                     <li>Let |value| be the value of |key|.</li>
-                    <li>Let |schema| be the value of |key| in |properties|.</li>
+                    <li>Let |propschema| be the value of |key| in |properties|.</li>
                     <li>
-                      Let |value| be the result of running these steps on |value|, |form| and |schema|. If this throws, then throw {{SyntaxError}} and abort these steps.
+                      Let |value| be the result of running the
+                      <a>create interaction data</a> steps on |value|, |form|
+                      and |propschema|.
+                      If this throws, then throw {{SyntaxError}} and abort these steps.
                     </li>
                   </ol>
                 </li>
                 <li>
-                  If |dataschema|'s |required| is an array, for each |item| in |required|
-                  check if |item| is a property name in |value|. If an |item| is
-                  not found in |value|, throw {{SyntaxError}} and abort these steps.
+                  If |schema|'s |required| is an array, for each |item| in |required|
+                  check if |item| is a property name in |source|. If an |item| is
+                  not found in |source|, throw {{SyntaxError}} and abort these steps.
+                </li>
+                <li>
+                  Set |data|'s [[\value]] to |source|.
                 </li>
               </ol>
             </li>
           </ol>
         </li>
         <li>
-          Let |data|'s |value| be |value|.
+          Set |idata|'s |data| to a new {{ReadableStream}} created from |idata|'s
+          [[\value]] <a>internal slot</a> as its
+          <a href="https://streams.spec.whatwg.org/#underlying-source">
+          underlying source</a>.
         </li>
         <li>
-          Return |data|.
+          Return |idata|.
         </li>
       </ol>
     </section>
+
+    <section><h3>The <dfn>parse interaction response</dfn> algorithm</h3>
+      For a given <a>ConsumedThing</a> object |thing:ConsumedThing|, in order to
+      <a>parse interaction response</a> given |response|, |form:Form| and
+      |schema:object|, run these steps:
+      <ol>
+        <li>
+          Let |result| be a new {{InteractionData}} object.
+        </li>
+        <li>
+          Let |result|'s |schema| be |schema|.
+        </li>
+        <li>
+          Let |result|'s |form| be |form|.
+        </li>
+        <li>
+          Let |result|'s |data| be a new {{ReadableStream}} with the payload data
+          of |response| as its
+          <a href="https://streams.spec.whatwg.org/#underlying-source">
+          underlying source</a>.
+        </li>
+        <li>
+          Let |result|'s |dataUsed| be `false`.
+        </li>
+        <li>
+          Return |result|.
+        </li>
+      </ol>
+    </section>
+
   </section>
 
   <section data-dfn-for="ExposedThing">

--- a/index.html
+++ b/index.html
@@ -478,7 +478,7 @@
       [SecureContext, Exposed=(Window,Worker)]
       interface ConsumedThing {
         constructor(ThingDescription td);
-        Promise&lt;any&gt; readProperty(DOMString propertyName,
+        Promise&lt;InteractionData&gt; readProperty(DOMString propertyName,
                                     optional InteractionOptions options = null);
         Promise&lt;PropertyMap&gt; readAllProperties(optional InteractionOptions options = null);
         Promise&lt;PropertyMap&gt; readMultipleProperties(
@@ -617,14 +617,15 @@
             If the request fails, reject |promise| with the error received from the <a>Protocol Bindings</a> and abort these steps.
           </li>
           <li>
-            Let |value| be the result of the request.
+            Let |response| be the response received to the request.
           </li>
           <li>
-            Let |reply| be the result of running <a>parse interaction data</a>
-            with |value| and |form|. If that fails, reject |promise| with a {{SyntaxError}} and abort these steps.
+            Let |data| be the result of running <a>parse interaction response</a>
+            on |response|, |form| and |interaction|.
+            If that fails, reject |promise| with a {{SyntaxError}} and abort these steps.
           </li>
           <li>
-            Resolve |promise| with |reply|.
+            Resolve |promise| with |data|.
           </li>
         </ol>
       </div>
@@ -658,8 +659,21 @@
             If this cannot be done with a single request with the <a>Protocol Bindings</a>, reject |promise| with a {{NotSupportedError}} and abort these steps.
           </li>
           <li>
-            Process the reply and update all properties in |result| with the
-            result of running <a>parse interaction data</a> on the values obtained in the reply.
+            Process the response and for each |key| in |result|, run the following
+            sub-steps:
+            <ol>
+              <li>
+                Let |value| be the value of |result|'s |key|.
+              </li>
+              <li>
+                Let |dataschema| be the value of ||td||'s |properties|'s |key|.
+              </li>
+              <li>
+                Let |property| be the result of running
+                <a>parse interaction response</a> on |value|, |form| and
+                |dataschema|.
+              </li>
+            </ol>
           </li>
           <li>
             If the above step fails at any point, reject |promise| with a {{SyntaxError}} and abort these steps.
@@ -702,10 +716,21 @@
             Process the reply and let |result:object| be an object with the keys and values obtained in the reply.
           </li>
           <li>
-            For each |key| in |result| having its value |value|, update |value|
-            with the result of running <a>parse interaction data</a> with |value|.
-            If that fails, reject |promise| with a {{SyntaxError}} and abort
-            these steps.
+            Process the response and for each |key| in |result|, run the following
+            sub-steps:
+            <ol>
+              <li>
+                Let |value| be the value of |result|'s |key|.
+              </li>
+              <li>
+                Let |dataschema| be the value of ||td||'s |properties|'s |key|.
+              </li>
+              <li>
+                Let |property| be the result of running
+                <a>parse interaction response</a> on |value|, |form| and
+                |dataschema|.
+              </li>
+            </ol>
           </li>
           <li>
             Resolve |promise| with |result|.
@@ -739,10 +764,13 @@
             If |form| is failure, reject |promise| with a {{SyntaxError}} and abort these steps.
           </li>
           <li>
-            Let |data| be the result of running the <a>create interaction data</a>steps on |value| and |form|. If that fails, reject <a>promise</a> with {{SyntaxError}} and abort these steps.
+            Let |data| be the result of running the <a>create interaction data</a>steps on |value|, |form| and |interaction|. If that fails, reject <a>promise</a> with {{SyntaxError}} and abort these steps.
           </li>
           <li>
-            Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to write |data| to the <a>Property</a> given by |propertyName| with |form| and optional URI templates given in |options|' {{uriVariables}}.
+            Make a request to the underlying platform (via the <a>Protocol Bindings</a>)
+            to write the <a>Property</a> given by |propertyName| using
+            |data:InteractionData| and the optional URI templates given in
+            |options|' {{uriVariables}}.
           </li>
           <li>
             If the request fails, reject |promise| with the error received from the <a>Protocol Bindings</a> and abort these steps.
@@ -769,32 +797,54 @@
         Writes a multiple <a>Property</a> values with one request. Takes a |properties:object| argument as an object with keys being <a>Property</a> names and values as <a>Property</a> values and an optional {{InteractionOptions}} |options:InteractionOptions| argument. It returns success or failure. The method MUST run the following steps:
         <ol>
           <li>
-            Return a {{Promise}} |promise:Promise| and execute the next steps <a>in parallel</a>.
+            Return a {{Promise}} |promise:Promise| and execute the next steps
+            <a>in parallel</a>.
           </li>
           <li>
-            If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
+            If invoking this method is not allowed for the current scripting
+            context for security reasons, reject |promise| with a
+            {{SecurityError}} and abort these steps.
           </li>
           <li>
             If |option|'s {{formIndex}} is defined, let |form| be the
-            <a>Form</a> associated with {{formIndex}} in ||td||'s |forms| array, otherwise let |form| be the first <a>Form</a> in ||td||'s |forms| array whose |op| is `writemultipleproperties`.
+            <a>Form</a> associated with {{formIndex}} in ||td||'s |forms| array,
+            otherwise let |form| be the first <a>Form</a> in ||td||'s |forms|
+            array whose |op| is `writemultipleproperties`.
           </li>
           <li>
-            If |form| is failure, reject |promise| with a {{SyntaxError}} and abort these steps.
+            If |form| is failure, reject |promise| with a {{SyntaxError}} and
+            abort these steps.
           </li>
           <li>
-            Let |result:object| be an object and for each string |name:string| in |propertyNames| add a property with key |name| and the value `null`.
+            Let |result:object| be an object and for each string |name:string| in |propertyNames| add a property with key |name| and let its value be
+            `null`.
           </li>
           <li>
-            For each key |name:string| in |properties|, take its value as |value| and run the <a>create interaction data</a> steps on |value| and |form|. If that fails for any |name|, reject <a>promise</a> with a {{SyntaxError}} and abort these steps.
+            Let |dataschemas:object| be an object and for each string |name:string|
+            in |propertyNames| add a property with key |name| and let its value
+            be the value of ||td||'s |properties|'s |name|.
           </li>
           <li>
-            Make a single request to the underlying platform (via the <a>Protocol Bindings</a>) to write each <a>Property</a> provided in |properties| with optional URI templates given in |options| {{uriVariables}}.
+            For each key |key:string| in |properties|, take its value as |value|
+            and run the <a>create interaction data</a> steps on |value|, |form|
+            and the value for |dataschema|'s |key|.
+            If that fails for any |name|, reject <a>promise</a> with a
+            {{SyntaxError}} and abort these steps.
           </li>
           <li>
-            If this cannot be done with a single request with the <a>Protocol Bindings</a> of the <a>Thing</a>, then reject |promise| with a {{NotSupportedError}} and abort these steps.
+            Make a single request to the underlying platform (via the
+            <a>Protocol Bindings</a>) to write each <a>Property</a> provided in
+            |properties| with optional URI templates given in |options|'
+            {{uriVariables}}.
           </li>
           <li>
-            If the request fails, return the error received from the <a>Protocol Bindings</a> and abort these steps.
+            If this cannot be done with a single request with the
+            <a>Protocol Bindings</a> of the <a>Thing</a>, then reject |promise|
+            with a {{NotSupportedError}} and abort these steps.
+          </li>
+          <li>
+            If the request fails, return the error received from the
+            <a>Protocol Bindings</a> and abort these steps.
           </li>
           <li>
             Otherwise resolve |promise|.
@@ -851,15 +901,14 @@
             Otherwise resolve |promise|.
           </li>
           <li>
-            Whenever the underlying platform receives a notification for this subscription with new <a>Property</a> value |value|, run
-            the following sub-steps:
+            Whenever the underlying platform receives a notification for this subscription with new <a>Property</a> value |value|, run the following sub-steps:
             <ul>
               <li>
-                Let |reply| be the result of running <a>parse interaction data</a>
-                with |value|. If that fails, reject |promise| with a {{SyntaxError}} and abort these steps.
+                Let |reply| be the result of running <a>parse interaction response</a>
+                with |value|, |form| and |interaction|. If that fails, reject |promise| with a {{SyntaxError}} and abort these steps.
               </li>
               <li>
-                Invoke |listener| with |reply| as parameter.
+                Invoke |listener| with |reply|.
               </li>
             </ul>
           </li>
@@ -940,8 +989,8 @@
             Let |value| be the reply returned in the reply.
           </li>
           <li>
-            Let |result| be the result of running <a>parse interaction data</a>
-            with |value| and |form|. If that fails, reject |promise| with a {{SyntaxError}} and abort these steps.
+            Let |result| be the result of running <a>parse interaction response</a>
+            with |value|, |form| and |interaction|. If that fails, reject |promise| with a {{SyntaxError}} and abort these steps.
           </li>
           <li>
             Resolve |promise| with |result|.
@@ -989,7 +1038,7 @@
           </li>
           <li>
             Whenever the underlying platform receives a notification for this <a>Event</a> subscription, implementations SHOULD invoke
-            |listener| with the result of running <a>parse interaction data</a> on the data provided with the <a>Event</a> and |form|.
+            |listener| with the result of running <a>parse interaction response</a> on the data provided with the <a>Event</a>, |form| and |interaction|.
           </li>
         </ol>
       </div>
@@ -1048,13 +1097,7 @@
         } catch(e) {
           console.log("TD fetch error: " + e.message); },
         };
-        function parseData(value) {
-          if (value instanceof InteractionData) {
-            const decoder = new TextDecoder();
-            return JSON.parse(decoder.decode(value.data));
-          }
-          return value;
-        };
+
         try {
           // subscribe to property change for “temperature”
           await thing.observeProperty("temperature", value => {
@@ -1070,6 +1113,7 @@
         } catch(e) {
           console.log("Error starting measurement.");
         }
+
         setTimeout( () => {
           console.log(“Temperature: “ +
             parseData(await thing.readProperty(“temperature”)));
@@ -1077,6 +1121,24 @@
           console.log("Unsubscribed from the ‘ready’ event.");
         },
         10000);
+
+        function parseData(response) {
+          if (response.value !== undefined)
+            return data.value;
+          // if response.value is undefined, it means parsing has failed
+          // app can try low-level stream read
+          const reader = value.data.getReader();
+          let value = null;
+
+          reader.read().then(function process({ done, chunk }) {
+              if (done) {
+                value += chunk;
+                return value
+              }
+              value += chunk;
+              return reader.read().then(process);
+            });
+        };
       </pre>
     </section> <!-- Examples -->
   </section> <!-- ConsumedThing -->
@@ -1085,162 +1147,158 @@
     <h2>The <dfn>InteractionData</dfn> interface</h2>
     <p>
       Belongs to the <a>WoT Consumer</a> conformance class.
-      Represents the data returned by <a>WoT Interactions</a> when no
-      explicit <a>DataSchema</a> is available for the <a>WoT Interaction</a>,
-      therefore applications need to rely on a <a href="https://www.w3.org/TR/2019/CR-wot-thing-description-20190516/#form">Form</a>'s `contentType`
-      defined for the <a>WoT Interaction</a>.
-      Implementations MAY always return an {{InteractionData}}
-      object for <a>WoT Interactions</a>, but MAY also parse the return data
-      according to the interaction's <a>DataSchema</a> when that is available.
+      Represents the data used by <a>WoT Interactions</a>.
     </p>
     <p class="ednote">
       Previously `any` has been used for representing data that
-      could be returned by <a>WoT Interactions</a>. Since data type can be
-      specified in the <a>TD</a> by a <a href="https://www.w3.org/TR/2019/CR-wot-thing-description-20190516/#form">Form</a>'s `contentType`
-      and optionally a <a>DataSchema</a>,
-      this interface enables handling returned data by applications.
+      could be returned by <a>WoT Interactions</a>. Data type is specified in
+      the <a>TD</a> by a <a href="https://www.w3.org/TR/2019/CR-wot-thing-description-20190516/#form">Form</a>'s `contentType`
+      and optionally a <a>DataSchema</a>.
+      This interface enables handling returned data by applications as a stream
+      or
     </p>
     <pre class="idl">
       [SecureContext, Exposed=(Window,Worker)]
       interface InteractionData {
-        readonly attribute DataView? data;
-        readonly attribute USVString? mediaType;
-        readonly attribute USVString? encoding;
-        readonly attribute USVString? lang;
+        readonly attribute any value;
+        readonly attribute ReadableStream? data;
         readonly attribute DataSchema? dataSchema;
+        readonly attribute Form? form;
       };
     </pre>
     <p>
-      The <dfn>data</dfn> property represents the returned payload from
+      The <dfn>value</dfn> property represents the parsed payload in
       <a>WoT Interactions</a>.
     </p>
     <p>
-      The <dfn>encoding</dfn> attribute represents the
-      <a href="https://encoding.spec.whatwg.org/#name">encoding name</a> used
-      for encoding the payload in the case it is textual data.
-    </p>
-    <p>
-      The <dfn>lang</dfn> attribute represents the [=language tag=]
-      of the payload in the case that was encoded.
-    </p>
-    <p>
-      A <dfn>language tag</dfn> is a <a>string</a> that matches the
-      production of a <code>Language-Tag</code> defined in the [[BCP47]]
-      specifications (see the <a href=
-      "http://www.iana.org/assignments/language-subtag-registry">IANA
-      Language Subtag Registry</a> for an authoritative list of possible
-      values).
+      The <dfn>data</dfn> property represents the raw payload in
+      <a>WoT Interactions</a> as a {{ReadableStream}}.
     </p>
     <p>
       The <dfn>dataSchema</dfn> attribute represents the <a>DataSchema</a>
-      of the payload when it is different from the one defined in the
-      <a>Thing Description</a>. If the value is `null`, then the `DataSchema`
-      of the <a>WoT Interaction</a> SHOULD be fetched from the <a>TD</a>.
+      of the payload as a {{JSON}} object.
+    </p>
+    <p>
+      The <dfn>form</dfn> attribute represents the <a>Form</a> selected from
+      the <a>Thing Description</a> for this <a>WoT Interaction</a>.
     </p>
 
-    <section><h3>The <dfn>parse interaction data</dfn> algorithm</h3>
-      For a given <a>WoT Interaction</a> |interaction| and <a>ConsumedThing</a>
-      object |thing:ConsumedThing|, in order to <a>parse interaction data</a>
-      given |rawData| and |form|, run these steps:
+    <section><h3>The <dfn>parse interaction response</dfn> algorithm</h3>
+      For a given <a>ConsumedThing</a> object |thing:ConsumedThing|, in order to
+      <a>parse interaction response</a> given |response|, |form:Form| and
+      |dataschema:object|, run these steps:
       <ol>
         <li>
-          If |form|'s |type| is defined, run these sub-steps:
-          <ol>
-            <li>
-              If |type| is `"null"`, let |result| be `null`.
-            </li>
-            <li>
-              If |type| is `"boolean"` and |rawData| is a falsy value, let
-              |result| be `false`, otherwise `true`.
-            </li>
-            <li>
-              If |type| is `"integer"` or `"number"`, let |result| be the number parsed from
-              |rawData|; if |form|'s |minimum| is defined and |result| is smaller,
-              or if |form|'s |maximum| is defined and |result| is bigger,
-              throw {{SyntaxError}} and abort these steps;
-            </li>
-            <li>
-              If |type| is `"string"`, let |result| be the string parsed from |rawData| with
-              the default language and encoding settings.
-              <p class="issue">
-                Need to define what are the default settings and how are they set.
-                See <a href="https://github.com/w3c/wot-scripting-api/issues/213">
-                issue #213</a>.
-              </p>
-            </li>
-            <li>
-              If |type| is `"array"`, run these sub-steps:
-              <ol>
-                <li>
-                  Let |length| be the length of |form|'s |items| array.
-                </li>
-                <li>
-                  If |form|'s |minItems| is defined and |length| is less than
-                  that, or if |form|'s |maxItems| is defined and |length| is
-                  more than that, throw {{SyntaxError}} and abort these steps.
-                </li>
-                <li>
-                  Split |rawData| in |length| number of equal chunks. If that fails,
-                  throw {{SyntaxError}} and abort these steps.
-                </li>
-                <li>
-                  Let |result| be an array of items obtained by
-                  running these steps on each |rawData| chunk and the |item| in |form|'s |items| of the same index. If this throws at any stage,
-                  throw {{SyntaxError}} and abort these steps.
-                </li>
-              </ol>
-            </li>
-            <li>
-              If |type| is `"object"`, run these sub-steps:
-              <ol>
-                <li>
-                  If |form|'s |properties| is not an object,
-                  throw {{SyntaxError}} and abort these steps.
-                </li>
-                <li>
-                  Let |result| be the result of running
-                  <a>parse JSON from bytes</a> on |rawData|.
-                </li>
-                <li>
-                  For each property |key| in |result|,
-                  <ol>
-                    <li>Let |value| be the value of |key|.</li>
-                    <li>Let |schema| be the value of |key| in |properties|.</li>
-                    <li>
-                      Let |value| be the result of running these steps on |value| and |schema|. If this throws, then throw {{SyntaxError}} and abort these steps.
-                    </li>
-                  </ol>
-                </li>
-              </ol>
-            </li>
-          </ol>
+          Let |result| be a new {{InteractionData}} object.
+        </li>
+        <li>
+          Let |result|'s |dataSchema| be |dataschema|.
+        </li>
+        <li>
+          Let |result|'s |form| be |form|.
+        </li>
+        <li>
+          Let |result|'s |data| be a new {{ReadableStream}} representation of
+          the payload data |response|.
+        </li>
+        <li>
+          Let |rawData| be the bytes representation of the payload data |response|.
+        </li>
+        <li>
+          Let |value| be `undefined`.
+        </li>
+        <li>
+          If |dataschema|'s |type| is defined, let |result|'s |value| be the
+          result of running the <a>parse data schema</a> sub-steps on
+          |rawData|, |form| and |dataschema|.
+          If that throws, let |result|'s |value| be `undefined`.
         </li>
         <li>
           Return |result| and abort these steps.
         </li>
+      </ol>
+      To run the <dfn>parse data schema</dfn> steps on |rawData|, |form| and
+      |dataschema|:
+      <ol>
         <li>
-          Otherwise, if |form|'s |type| is not defined, run these sub-steps
+          Let |type| be |dataschema|'s |type|.
+        </li>
+        <li>
+          If |type| is `"null"`, return `null`.
+        </li>
+        <li>
+          If |type| is `"boolean"` and |rawData| is a falsy value, return
+          `false`, otherwise return `true`.
+        </li>
+        <li>
+          If |type| is `"integer"` or `"number"`, let |value| be the number
+          parsed from |rawData|; if |form|'s |minimum| is defined and
+          |result| is smaller, or if |form|'s |maximum| is defined and
+          |result| is bigger, throw {{SyntaxError}} and abort these steps;
+        </li>
+        <li>
+          If |type| is `"string"`, let |value| be the string parsed from
+          |rawData| using |form|'s |contentType| and |contentCoding|.
+        </li>
+        <li>
+          If |type| is `"array"`, run these sub-steps:
           <ol>
             <li>
-              Let |result| be a new {{InteractionData}} object with all its properties
-              set to `null`.
+              Let |length| be the length of |form|'s |items| array.
             </li>
             <li>
-              Let |result|'s |data| be a new {{DataView}} created from |rawData|.
+              If |form|'s |minItems| is defined and |length| is less than
+              that, or if |form|'s |maxItems| is defined and |length| is
+              more than that, throw {{SyntaxError}} and abort these steps.
             </li>
             <li>
-              Let |result|'s |mediaType| be |form|'s |contentType|.
+              Split |rawData| in |length| number of equal chunks. If that fails,
+              throw {{SyntaxError}} and abort these steps.
             </li>
             <li>
-              Set |result|'s |encoding| to the
-              <a href="https://encoding.spec.whatwg.org/#name">encoding name</a>
-              if that is available.
+              Let |value| be an array of items obtained by
+              running these steps on each |rawData| chunk and the |item| in
+              |form|'s |items| of the same index. If this throws at any stage,
+              throw {{SyntaxError}} and abort these steps.
+            </li>
+          </ol>
+        </li>
+        <li>
+          If |type| is `"object"`, run these sub-steps:
+          <ol>
+            <li>
+              If |dataschema|'s |properties| is not an object,
+              throw {{SyntaxError}} and abort these steps.
             </li>
             <li>
-              Set |result|'s |lang| to the [=language tag=] if available.
+              Let |value| be the result of running
+              <a>parse JSON from bytes</a> on |rawData|.
             </li>
             <li>
-              Return |result|.
+              For each property |key| in |value|,
+              <ol>
+                <li>Let |prop| be the value of |key|.</li>
+                <li>
+                  Let |schema| be the value of |key| in |interaction|'s
+                  |properties|.
+                </li>
+                <li>
+                  Let |prop| be the result of running the
+                  <a>parse data schema</a> steps on |prop|, |form| and |schema|.
+                  If this throws, then throw {{SyntaxError}} and abort these steps.
+                </li>
+              </ol>
+            </li>
+            <li>
+              Let |required| be |dataschema|'s |required| if that is an array
+              or an empty array otherwise.
+            </li>
+            <li>
+              For each |key| in |required|, if |key| is not present in |value|,
+              throw {{SyntaxError}} and abort these steps.
+            </li>
+            <li>
+              Return |value|.
             </li>
           </ol>
         </li>
@@ -1248,54 +1306,49 @@
     </section>
 
     <section><h3>The <dfn>create interaction data</dfn> algorithm</h3>
-      For a given <a>WoT Interaction</a> |interaction| and <a>ConsumedThing</a>
-      object |thing:ConsumedThing|, in order to <a>create interaction data</a>
-      given |data| and |form|, run these steps:
+      For a given <a>ConsumedThing</a> object |thing:ConsumedThing|, in order to
+      <a>create interaction data</a> given |value|, |form:Form| and
+      |dataschema:object|, run these steps:
       <ol>
         <li>
-          If |data| is an {{InteractionData}} object, run these sub-steps:
-          <ol>
-            <li>
-              If |form|'s |contentType| and |data|'s |mediaType| are defined,
-              but not equal, throw {{SyntaxError}} and abort these steps.
-            </li>
-            <li>
-              If |data|'s |mediaType| is not defined, let it be |form|'s |contentType|.
-            </li>
-            <li>
-              Return |data| and abort these steps.
-            </li>
-          </ol>
+          If |value| is an {{InteractionData}} object whose |data| is a
+          {{ReadableStream}}, return |value| and abort these steps.
         </li>
         <li>
-          If |form|'s |type| is defined, run these sub-steps:
+          Let |data| be a new an {{InteractionData}} object whose |value| is
+          `undefined`, whose |form| is |form|, whose |dataSchema| is |dataschema|
+          and whose |data| is `null`.
+        </li>
+        <li>
+          If |dataschema|'s |type| is defined, run these sub-steps:
           <ol>
             <li>
-              If |type| is `"null"` and |data| is not, throw {{SyntaxError}} and abort these steps.
-            </li>
-            <li>
-              If |type| is `"boolean"` and |data| is a falsy value, let
-              |data| be `false`, otherwise `true`.
-            </li>
-            <li>
-              If |type| is `"integer"` or `"number"` and |data| is not a number,
-              or if |form|'s |minimum| is defined and |data| is smaller,
-              or if |form|'s |maximum| is defined and |data| is bigger,
+              If |type| is `"null"` and |value| is not,
               throw {{SyntaxError}} and abort these steps.
             </li>
             <li>
-              If |type| is `"string"` and |data| is not a string, let |data| be
-              the result of running <a>serialize JSON to bytes</a> on |data|.
+              If |type| is `"boolean"` and |value| is a falsy value, let
+              |value| be `false`, otherwise `true`.
+            </li>
+            <li>
+              If |type| is `"integer"` or `"number"` and |value| is not a number,
+              or if |form|'s |minimum| is defined and |value| is smaller,
+              or if |form|'s |maximum| is defined and |value| is bigger,
+              throw {{SyntaxError}} and abort these steps.
+            </li>
+            <li>
+              If |type| is `"string"` and |value| is not a string, let |value| be
+              the result of running <a>serialize JSON to bytes</a> on |value|.
               If that is failure, throw {{SyntaxError}} and abort these steps.
             </li>
             <li>
               If |type| is `"array"`, run these sub-steps:
               <ol>
                 <li>
-                  If |data| is not an array, throw {{SyntaxError}} and abort these steps.
+                  If |value| is not an array, throw {{SyntaxError}} and abort these steps.
                 </li>
                 <li>
-                  Let |length| be the length of |data|.
+                  Let |length| be the length of |value|.
                 </li>
                 <li>
                   If |form|'s |minItems| is defined and |length| is less than
@@ -1303,13 +1356,10 @@
                   more than that, throw {{SyntaxError}} and abort these steps.
                 </li>
                 <li>
-                  For each item in |data|,  |rawData| in |length| number of equal chunks. If that fails,
-                  throw {{SyntaxError}} and abort these steps.
-                </li>
-                <li>
-                  For each |item| in |data| with |index|, let |item| be the
-                  result of running these steps on |item| and |schema| obtained
-                  from |form|'s |items| at |index|. If this throws at any stage,
+                  For each |item| in |value| with |index|, let |schema| be
+                  |dataschema|'s |items| at |index| and let |item| be the
+                  result of running these steps on |item|, |form| and |schema|.
+                  If this throws at any stage,
                   throw {{SyntaxError}} and abort these steps.
                 </li>
               </ol>
@@ -1318,30 +1368,36 @@
               If |type| is `"object"`, run these sub-steps:
               <ol>
                 <li>
-                  If |data| is not an object, throw {{SyntaxError}} and abort these steps.
+                  If |value| is not an object, throw {{SyntaxError}} and abort these steps.
                 </li>
                 <li>
-                  If |form|'s |properties| is not an object,
+                  If |dataschema|'s |properties| is not an object,
                   throw {{SyntaxError}} and abort these steps.
                 </li>
                 <li>
-                  For each property |key| in |data|,
+                  For each property |key| in |value|,
                   <ol>
                     <li>Let |value| be the value of |key|.</li>
                     <li>Let |schema| be the value of |key| in |properties|.</li>
                     <li>
-                      Let |value| be the result of running these steps on |value| and |schema|. If this throws, then throw {{SyntaxError}} and abort these steps.
+                      Let |value| be the result of running these steps on |value|, |form| and |schema|. If this throws, then throw {{SyntaxError}} and abort these steps.
                     </li>
                   </ol>
                 </li>
                 <li>
-                  If |form|'s |required| is defined, for each of its |item|
-                  check if |item| is a property in |data|. If an |item| is
-                  not found in |result|, throw {{SyntaxError}} and abort these steps.
+                  If |dataschema|'s |required| is an array, for each |item| in |required|
+                  check if |item| is a property name in |value|. If an |item| is
+                  not found in |value|, throw {{SyntaxError}} and abort these steps.
                 </li>
               </ol>
             </li>
           </ol>
+        </li>
+        <li>
+          Let |data|'s |value| be |value|.
+        </li>
+        <li>
+          Return |data|.
         </li>
       </ol>
     </section>
@@ -2270,7 +2326,7 @@
       <dfn data-cite="!HTML#global-object">global object</dfn>,
       <dfn data-cite="!HTML#current-settings-object">current settings object</dfn>,
       executing algorithms <dfn data-cite="!HTML#in-parallel">in parallel</dfn>
-       are defined in [[!HTML5]] and are used in the context of browser implementations.[=language tag=]
+       are defined in [[!HTML5]] and are used in the context of browser implementations.
     </p>
     <p>
       The term

--- a/index.html
+++ b/index.html
@@ -401,7 +401,7 @@
           If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
         </li>
         <li>
-          Run the <a>validate a TD</a> steps on |td|. If that [= exception/throws =], reject |promise| with that error and abort these steps.
+          Run the <a>validate a TD</a> steps on |td|. If that fails, reject |promise| with {{SyntaxError}} and abort these steps.
         </li>
         <li>
           Let |thing:ConsumedThing| be a new {{ConsumedThing}} object constructed from |td|.
@@ -607,15 +607,8 @@
             Let |value| be the result of the request.
           </li>
           <li>
-            Run the <dfn>validate Property value</dfn> sub-steps on |value|:
-            <ol>
-              <li>
-                Based on the <a href="https://www.w3.org/TR/2019/CR-wot-thing-description-20190516/#dataschema">DataSchema definition</a>, |value| MUST be a JSON value and comply to the data schema defined for the <a>Property</a> that is found in <a>Thing Description</a>. If this fails, [= exception/throw =] a {{"SyntaxError"}} and abort these sub-steps.
-              </li>
-              <li>
-                Return |reply|.
-              </li>
-            </ol>
+            Run the <a>validate Property value</a> steps on |value|.
+            If that fails, reject |promise| with {{SyntaxError}} and abort these steps.
           </li>
           <li>
             Let |reply| be the result of running <a>create reply data</a>
@@ -1064,6 +1057,20 @@
       <p class="ednote">
         These steps need to be expanded and defined in more detail.
       </p>
+    </section>
+    <section><h3>The <dfn>validate Property value</dfn> algorithm</h3>
+      To <a>validate Property value</a> given |value|, run the following steps:
+      <ol>
+        <li>
+          Based on the <a href="https://www.w3.org/TR/2019/CR-wot-thing-description-20190516/#dataschema">DataSchema definition</a>, |value| MUST be a JSON value and comply to the data schema defined for the <a>Property</a> that is found in <a>Thing Description</a>.
+        </li>
+        <li>
+           If that fails, [= exception/throw =] a {{"SyntaxError"}} and abort these steps.
+        </li>
+        <li>
+          Return |reply|.
+        </li>
+      </ol>
     </section>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -509,7 +509,7 @@
         object uriVariables;
       };
       typedef object PropertyMap;
-      callback WotListener = void(InteractionData data);
+      callback WotListener = void(any data);
     </pre>
 
     <section>
@@ -1048,18 +1048,21 @@
         } catch(e) {
           console.log("TD fetch error: " + e.message); },
         };
+        function parseData(value) {
+          if (value instanceof InteractionData) {
+            const decoder = new TextDecoder();
+            return JSON.parse(decoder.decode(value.data));
+          }
+          return value;
+        };
         try {
           // subscribe to property change for “temperature”
           await thing.observeProperty("temperature", value => {
-            const decoder = new TextDecoder();
-            const data = JSON.parse(decoder.decode(value.data));
-            console.log("Temperature changed to: " + data);
+            console.log("Temperature changed to: " + parseData(value));
           });
           // subscribe to the “ready” event defined in the TD
           await thing.subscribeEvent("ready", eventData => {
-            const decoder = new TextDecoder();
-            const data = JSON.parse(decoder.decode(value.data));
-            console.log("Ready; index: " + data);
+            console.log("Ready; index: " + parseData(eventData));
             // run the “startMeasurement” action defined by TD
             await thing.invokeAction("startMeasurement", { units: "Celsius" });
             console.log("Measurement started.");
@@ -1068,7 +1071,8 @@
           console.log("Error starting measurement.");
         }
         setTimeout( () => {
-          console.log(“Temperature: “ + await thing.readProperty(“temperature”));
+          console.log(“Temperature: “ +
+            parseData(await thing.readProperty(“temperature”)));
           await thing.unsubscribe(“ready”);
           console.log("Unsubscribed from the ‘ready’ event.");
         },
@@ -1085,7 +1089,7 @@
       explicit <a>DataSchema</a> is available for the <a>WoT Interaction</a>,
       therefore applications need to rely on a <a href="https://www.w3.org/TR/2019/CR-wot-thing-description-20190516/#form">Form</a>'s `contentType`
       defined for the <a>WoT Interaction</a>.
-      Implementations MAY always return an <a>InteractionData</a>
+      Implementations MAY always return an {{InteractionData}}
       object for <a>WoT Interactions</a>, but MAY also parse the return data
       according to the interaction's <a>DataSchema</a> when that is available.
     </p>

--- a/index.html
+++ b/index.html
@@ -478,18 +478,18 @@
       [SecureContext, Exposed=(Window,Worker)]
       interface ConsumedThing {
         constructor(ThingDescription td);
-        Promise&lt;InteractionData&gt; readProperty(DOMString propertyName,
-                                  optional InteractionOptions options = null);
+        Promise&lt;any&gt; readProperty(DOMString propertyName,
+                                    optional InteractionOptions options = null);
         Promise&lt;PropertyMap&gt; readAllProperties(optional InteractionOptions options = null);
         Promise&lt;PropertyMap&gt; readMultipleProperties(
-                                  sequence&lt;DOMString&gt; propertyNames,
-                                  optional InteractionOptions options = null);
+                                    sequence&lt;DOMString&gt; propertyNames,
+                                    optional InteractionOptions options = null);
         Promise&lt;void&gt; writeProperty(DOMString propertyName,
                                     any value,
                                     optional InteractionOptions options = null);
         Promise&lt;void&gt; writeMultipleProperties(PropertyMap valueMap,
                                     optional InteractionOptions options = null);
-        Promise&lt;InteractionData&gt; invokeAction(DOMString actionName,
+        Promise&lt;any&gt; invokeAction(DOMString actionName,
                                     optional any params = null,
                                     optional InteractionOptions options = null);
         Promise&lt;void&gt; observeProperty(DOMString name,
@@ -598,7 +598,20 @@
             If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
           </li>
           <li>
-            Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to retrieve the value of the <a>Property</a> given by |propertyName| with optional URI templates given in |options|' {{uriVariables}}.
+            Let |interaction| be the value of ||td||'s |properties|'s
+            |propertyName|.
+          </li>
+          <li>
+            If |option|'s {{formIndex}} is defined, let |form| be the
+            <a>Form</a> associated with {{formIndex}} in |interaction|'s |forms|
+            array, otherwise let |form| be the first <a>Form</a> in
+            |interaction|'s |forms| whose |op| is `readproperty`.
+          </li>
+          <li>
+            If |form| is failure, reject |promise| with a {{SyntaxError}} and abort these steps.
+          </li>
+          <li>
+            Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to retrieve the value of the <a>Property</a>given by |propertyName| using |form| and the optional URI templates given in |options|' {{uriVariables}}.
           </li>
           <li>
             If the request fails, reject |promise| with the error received from the <a>Protocol Bindings</a> and abort these steps.
@@ -607,19 +620,11 @@
             Let |value| be the result of the request.
           </li>
           <li>
-            Run the <a>validate Property value</a> steps on |value|.
-            If that fails, reject |promise| with {{SyntaxError}} and abort these steps.
+            Let |reply| be the result of running <a>parse interaction data</a>
+            with |value| and |form|. If that fails, reject |promise| with a {{SyntaxError}} and abort these steps.
           </li>
           <li>
-            Let |reply| be the result of running <a>create reply data</a>
-            with |value|. If that fails, reject |promise| with a {{SyntaxError}} and abort these steps.
-          </li>
-          <li>
-            If these above sub-steps failed, reject |promise| with
-            {{SyntaxError}} and abort these steps.
-          </li>
-          <li>
-            Otherwise resolve |promise| with |value|.
+            Resolve |promise| with |reply|.
           </li>
         </ol>
       </div>
@@ -637,17 +642,24 @@
             If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
           </li>
           <li>
+            If |option|'s {{formIndex}} is defined, let |form| be the
+            <a>Form</a> associated with {{formIndex}} in ||td||'s |forms| array, otherwise let |form| be the first <a>Form</a> in ||td||'s |forms| array whose |op| is `readmultipleproperties`.
+          </li>
+          <li>
+            If |form| is failure, reject |promise| with a {{SyntaxError}} and abort these steps.
+          </li>
+          <li>
             Let |result:object| be an object and for each string |name:string| in |propertyNames| add a property with key |name| and the value `null`.
           </li>
           <li>
-            Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to retrieve the <a>Property</a> values given by |propertyNames| with optional URI templates given in |options|' {{uriVariables}}.
+            Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to retrieve the <a>Property</a> values given by |propertyNames| with |form| and optional URI templates given in |options|' {{uriVariables}}.
           </li>
           <li>
-            If this cannot be done with a single request with the <a>Protocol Bindings</a> of the <a>Thing</a>, then reject |promise| with a {{NotSupportedError}} and abort these steps.
+            If this cannot be done with a single request with the <a>Protocol Bindings</a>, reject |promise| with a {{NotSupportedError}} and abort these steps.
           </li>
           <li>
             Process the reply and update all properties in |result| with the
-            result of running <a>create reply data</a> on the values obtained in the reply.
+            result of running <a>parse interaction data</a> on the values obtained in the reply.
           </li>
           <li>
             If the above step fails at any point, reject |promise| with a {{SyntaxError}} and abort these steps.
@@ -671,7 +683,14 @@
             If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
           </li>
           <li>
-            Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to retrieve the value of the all the <a>Property</a> definitions from the <a>TD</a> with optional URI templates given in |options|' {{uriVariables}}.
+            If |option|'s {{formIndex}} is defined, let |form| be the
+            <a>Form</a> associated with {{formIndex}} in ||td||'s |forms| array, otherwise let |form| be the first <a>Form</a> in ||td||'s |forms| array whose |op| is `readallproperties`.
+          </li>
+          <li>
+            If |form| is failure, reject |promise| with a {{SyntaxError}} and abort these steps.
+          </li>
+          <li>
+            Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to retrieve the value of the all the <a>Property</a> definitions from the <a>TD</a> with |form| and optional URI templates given in |options|' {{uriVariables}}.
           </li>
           <li>
             If this cannot be done with a single request with the <a>Protocol Bindings</a> of the <a>Thing</a>, then reject |promise| with a {{NotSupportedError}} and abort these steps.
@@ -684,7 +703,7 @@
           </li>
           <li>
             For each |key| in |result| having its value |value|, update |value|
-            with the result of running <a>create reply data</a> with |value|.
+            with the result of running <a>parse interaction data</a> with |value|.
             If that fails, reject |promise| with a {{SyntaxError}} and abort
             these steps.
           </li>
@@ -707,10 +726,23 @@
             If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
           </li>
           <li>
-            Run the <a>validate Property value</a> steps on |value|. If that fails, reject <a>promise</a> with {{SyntaxError}} and abort these steps.
+            Let |interaction| be the value of ||td||'s |properties|'s
+            |propertyName|.
           </li>
           <li>
-            Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to write |value| to the <a>Property</a> given by |propertyName| with optional URI templates given in |options.uriVariables|.
+            If |option|'s {{formIndex}} is defined, let |form| be the
+            <a>Form</a> associated with {{formIndex}} in |interaction|'s |forms|
+            array, otherwise let |form| be the first <a>Form</a> in
+            |interaction|'s |forms| whose |op| is `writeproperty`.
+          </li>
+          <li>
+            If |form| is failure, reject |promise| with a {{SyntaxError}} and abort these steps.
+          </li>
+          <li>
+            Let |data| be the result of running the <a>create interaction data</a>steps on |value| and |form|. If that fails, reject <a>promise</a> with {{SyntaxError}} and abort these steps.
+          </li>
+          <li>
+            Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to write |data| to the <a>Property</a> given by |propertyName| with |form| and optional URI templates given in |options|' {{uriVariables}}.
           </li>
           <li>
             If the request fails, reject |promise| with the error received from the <a>Protocol Bindings</a> and abort these steps.
@@ -743,7 +775,17 @@
             If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
           </li>
           <li>
-            For each key |name:string| in |properties|, take its value as |value| and run the <a>validate Property value</a> steps on |value|. If that fails for any |name|, reject <a>promise</a> with a {{SyntaxError}} and abort these steps.
+            If |option|'s {{formIndex}} is defined, let |form| be the
+            <a>Form</a> associated with {{formIndex}} in ||td||'s |forms| array, otherwise let |form| be the first <a>Form</a> in ||td||'s |forms| array whose |op| is `writemultipleproperties`.
+          </li>
+          <li>
+            If |form| is failure, reject |promise| with a {{SyntaxError}} and abort these steps.
+          </li>
+          <li>
+            Let |result:object| be an object and for each string |name:string| in |propertyNames| add a property with key |name| and the value `null`.
+          </li>
+          <li>
+            For each key |name:string| in |properties|, take its value as |value| and run the <a>create interaction data</a> steps on |value| and |form|. If that fails for any |name|, reject <a>promise</a> with a {{SyntaxError}} and abort these steps.
           </li>
           <li>
             Make a single request to the underlying platform (via the <a>Protocol Bindings</a>) to write each <a>Property</a> provided in |properties| with optional URI templates given in |options| {{uriVariables}}.
@@ -787,7 +829,20 @@
             with a {{TypeError}} and abort these steps.
           </li>
           <li>
-            Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to observe <a>Property</a> identified by |propertyName| with optional URI templates given in |options|' {{uriVariables}}.
+            Let |interaction| be the value of ||td||'s |properties|'s
+            |propertyName|.
+          </li>
+          <li>
+            If |option|'s {{formIndex}} is defined, let |form| be the
+            <a>Form</a> associated with {{formIndex}} in |interaction|'s |forms|
+            array, otherwise let |form| be the first <a>Form</a> in
+            |interaction|'s |forms| array whose |op| is `observeproperty`.
+          </li>
+          <li>
+            If |form| is failure, reject |promise| with a {{SyntaxError}} and abort these steps.
+          </li>
+          <li>
+            Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to observe <a>Property</a> identified by |propertyName| with |form| and optional URI templates given in |options|' {{uriVariables}}.
           </li>
           <li>
             If the request fails, reject |promise| with the error received from the <a>Protocol Bindings</a> and abort these steps.
@@ -800,10 +855,7 @@
             the following sub-steps:
             <ul>
               <li>
-                If running the <a>validate Property value</a> steps on |value| fails, abort these steps.
-              </li>
-              <li>
-                Let |reply| be the result of running <a>create reply data</a>
+                Let |reply| be the result of running <a>parse interaction data</a>
                 with |value|. If that fails, reject |promise| with a {{SyntaxError}} and abort these steps.
               </li>
               <li>
@@ -828,7 +880,20 @@
             If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
           </li>
           <li>
-            Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to stop observing the <a>Property</a> identified by |propertyName|, with optional URI templates given in |options|'
+            Let |interaction| be the value of ||td||'s |properties|'s
+            |propertyName|.
+          </li>
+          <li>
+            If |option|'s {{formIndex}} is defined, let |form| be the
+            <a>Form</a> associated with {{formIndex}} in |interaction|'s |forms|
+            array, otherwise let |form| be the first <a>Form</a> in
+            |interaction|'s |forms| array whose |op| is `unobserveproperty`.
+          </li>
+          <li>
+            If |form| is failure, reject |promise| with a {{SyntaxError}} and abort these steps.
+          </li>
+          <li>
+            Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to stop observing the <a>Property</a> identified by |propertyName|, with |form| and optional URI templates given in |options|'
             {{uriVariables}}.
           </li>
           <li>
@@ -853,20 +918,33 @@
             If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
           </li>
           <li>
-            Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to invoke the <a>Action</a> identified by |actionName| with parameters provided in |params| with optional URI templates given in |options|'s {{uriVariables}}.
+            Let |interaction| be the value of ||td||'s |actions|'s
+            |actionName|.
+          </li>
+          <li>
+            If |option|'s {{formIndex}} is defined, let |form| be the
+            <a>Form</a> associated with {{formIndex}} in |interaction|'s |forms|
+            array, otherwise let |form| be the first <a>Form</a> in
+            |interaction|'s |forms| array whose |op| is `invokeaction`.
+          </li>
+          <li>
+            If |form| is failure, reject |promise| with a {{SyntaxError}} and abort these steps.
+          </li>
+          <li>
+            Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to invoke the <a>Action</a> identified by |actionName| with parameters provided in |params| with |form| and optional URI templates given in |options|'s {{uriVariables}}.
           </li>
           <li>
             If the request fails locally or returns an error over the network, reject |promise| with the error received from the <a>Protocol Bindings</a> and abort these steps.
           </li>
           <li>
-            Otherwise let |value| be the result returned in the reply and run the <a>validate Property value</a> steps on it. If that fails, reject |promise| with a {{SyntaxError}} and abort these steps.
+            Let |value| be the reply returned in the reply.
           </li>
           <li>
-            Let |reply| be the result of running <a>create reply data</a>
-            with |value|. If that fails, reject |promise| with a {{SyntaxError}} and abort these steps.
+            Let |result| be the result of running <a>parse interaction data</a>
+            with |value| and |form|. If that fails, reject |promise| with a {{SyntaxError}} and abort these steps.
           </li>
           <li>
-            Resolve |promise| with |reply|.
+            Resolve |promise| with |result|.
           </li>
         </ol>
       </div>
@@ -889,7 +967,19 @@
             with a {{TypeError}} and abort these steps.
           </li>
           <li>
-            Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to subscribe to an <a>Event</a> identified by |eventName:string| with optional URI templates given in |options|' {{uriVariables}}.
+            Let |interaction| be the value of ||td||'s |events|'s |eventName|.
+          </li>
+          <li>
+            If |option|'s {{formIndex}} is defined, let |form| be the
+            <a>Form</a> associated with {{formIndex}} in |interaction|'s |forms|
+            array, otherwise let |form| be the first <a>Form</a> in
+            |interaction|'s |forms| array whose |op| is `subscribeevent`.
+          </li>
+          <li>
+            If |form| is failure, reject |promise| with a {{SyntaxError}} and abort these steps.
+          </li>
+          <li>
+            Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to subscribe to an <a>Event</a> identified by |eventName:string| with |form| and optional URI templates given in |options|' {{uriVariables}}.
           </li>
           <li>
             If the request fails, reject |promise| with the error received from the <a>Protocol Bindings</a> and abort these steps.
@@ -899,7 +989,7 @@
           </li>
           <li>
             Whenever the underlying platform receives a notification for this <a>Event</a> subscription, implementations SHOULD invoke
-            |listener| with the result of running <a>create reply data</a> on the data provided with the <a>Event</a>.
+            |listener| with the result of running <a>parse interaction data</a> on the data provided with the <a>Event</a> and |form|.
           </li>
         </ol>
       </div>
@@ -917,14 +1007,28 @@
             If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
           </li>
           <li>
-            Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to unsubscribe from the <a>Event</a> identified by |eventName|
-            with optional URI templates given in |options|' {{uriVariables}}.
+            Let |interaction| be the value of ||td||'s |events|'s |eventName|.
+          </li>
+          <li>
+            If |option|'s {{formIndex}} is defined, let |form| be the
+            <a>Form</a> associated with {{formIndex}} in |interaction|'s |forms|
+            array, otherwise let |form| be the first <a>Form</a> in
+            |interaction|'s |forms| array whose |op| is `unsubscribeevent`.
+          </li>
+          <li>
+            If |form| is failure, reject |promise| with a {{SyntaxError}} and abort these steps.
+          </li>
+          <li>
+            Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to unsubscribe from the <a>Event</a> identified by |eventName| with |form| and optional URI templates given in |options|' {{uriVariables}}.
           </li>
           <li>
             If the request fails, reject |promise| with the error received from the <a>Protocol Bindings</a> and abort these steps.
           </li>
           <li>
-            Otherwise resolve |promise|.
+            Resolve |promise|.
+          </li>
+          <li>
+            If the underlying platform receives further notifications for this <a>Event</a> subscription, implementations SHOULD silently suppress them.
           </li>
         </ol>
       </div>
@@ -976,8 +1080,14 @@
   <section data-dfn-for="InteractionData">
     <h2>The <dfn>InteractionData</dfn> interface</h2>
     <p>
-      Represents the data returned by <a>WoT Interactions</a>. Belongs to the
-      <a>WoT Consumer</a> conformance class.
+      Belongs to the <a>WoT Consumer</a> conformance class.
+      Represents the data returned by <a>WoT Interactions</a> when no
+      explicit <a>DataSchema</a> is available for the <a>WoT Interaction</a>,
+      therefore applications need to rely on a <a href="https://www.w3.org/TR/2019/CR-wot-thing-description-20190516/#form">Form</a>'s `contentType`
+      defined for the <a>WoT Interaction</a>.
+      Implementations MAY always return an <a>InteractionData</a>
+      object for <a>WoT Interactions</a>, but MAY also parse the return data
+      according to the interaction's <a>DataSchema</a> when that is available.
     </p>
     <p class="ednote">
       Previously `any` has been used for representing data that
@@ -1023,52 +1133,211 @@
       <a>Thing Description</a>. If the value is `null`, then the `DataSchema`
       of the <a>WoT Interaction</a> SHOULD be fetched from the <a>TD</a>.
     </p>
-    <section><h3>The <dfn>create reply data</dfn> algorithm</h3>
+
+    <section><h3>The <dfn>parse interaction data</dfn> algorithm</h3>
       For a given <a>WoT Interaction</a> |interaction| and <a>ConsumedThing</a>
-      object |thing:ConsumedThing|, in order to <a>create reply data</a>
-      given the |rawData| argument, run these steps:
+      object |thing:ConsumedThing|, in order to <a>parse interaction data</a>
+      given |rawData| and |form|, run these steps:
       <ol>
         <li>
-          Let |result| be a new {{InteractionData}} object with all its properties
-          set to `null`.
+          If |form|'s |type| is defined, run these sub-steps:
+          <ol>
+            <li>
+              If |type| is `"null"`, let |result| be `null`.
+            </li>
+            <li>
+              If |type| is `"boolean"` and |rawData| is a falsy value, let
+              |result| be `false`, otherwise `true`.
+            </li>
+            <li>
+              If |type| is `"integer"` or `"number"`, let |result| be the number parsed from
+              |rawData|; if |form|'s |minimum| is defined and |result| is smaller,
+              or if |form|'s |maximum| is defined and |result| is bigger,
+              throw {{SyntaxError}} and abort these steps;
+            </li>
+            <li>
+              If |type| is `"string"`, let |result| be the string parsed from |rawData| with
+              the default language and encoding settings.
+              <p class="issue">
+                Need to define what are the default settings and how are they set.
+                See <a href="https://github.com/w3c/wot-scripting-api/issues/213">
+                issue #213</a>.
+              </p>
+            </li>
+            <li>
+              If |type| is `"array"`, run these sub-steps:
+              <ol>
+                <li>
+                  Let |length| be the length of |form|'s |items| array.
+                </li>
+                <li>
+                  If |form|'s |minItems| is defined and |length| is less than
+                  that, or if |form|'s |maxItems| is defined and |length| is
+                  more than that, throw {{SyntaxError}} and abort these steps.
+                </li>
+                <li>
+                  Split |rawData| in |length| number of equal chunks. If that fails,
+                  throw {{SyntaxError}} and abort these steps.
+                </li>
+                <li>
+                  Let |result| be an array of items obtained by
+                  running these steps on each |rawData| chunk and the |item| in |form|'s |items| of the same index. If this throws at any stage,
+                  throw {{SyntaxError}} and abort these steps.
+                </li>
+              </ol>
+            </li>
+            <li>
+              If |type| is `"object"`, run these sub-steps:
+              <ol>
+                <li>
+                  If |form|'s |properties| is not an object,
+                  throw {{SyntaxError}} and abort these steps.
+                </li>
+                <li>
+                  Let |result| be the result of running
+                  <a>parse JSON from bytes</a> on |rawData|.
+                </li>
+                <li>
+                  For each property |key| in |result|,
+                  <ol>
+                    <li>Let |value| be the value of |key|.</li>
+                    <li>Let |schema| be the value of |key| in |properties|.</li>
+                    <li>
+                      Let |value| be the result of running these steps on |value| and |schema|. If this throws, then throw {{SyntaxError}} and abort these steps.
+                    </li>
+                  </ol>
+                </li>
+              </ol>
+            </li>
+          </ol>
         </li>
         <li>
-          Let |result|'s |data| be a new {{DataView}} created from |rawData|.
+          Return |result| and abort these steps.
         </li>
         <li>
-          If |thing|'s <a>internal slot</a> ||td|| is not defined,
-          return |result| and abort these steps.
-        </li>
-        <li>
-          Let |form:Form| be the <a>Form</a> used for |interaction|.
-        </li>
-        <li>
-          Let |result|'s |mediaType| be |form|'s |contentType|.
-        </li>
-        <li>
-          If |rawData| is text, set |result|'s |encoding| to the text encoding
-          value of |rawData| and set |result|'s |lang| to the [=language tag=]
-          associated with |rawData|.
-        </li>
-        <li>
-          Return |result|.
+          Otherwise, if |form|'s |type| is not defined, run these sub-steps
+          <ol>
+            <li>
+              Let |result| be a new {{InteractionData}} object with all its properties
+              set to `null`.
+            </li>
+            <li>
+              Let |result|'s |data| be a new {{DataView}} created from |rawData|.
+            </li>
+            <li>
+              Let |result|'s |mediaType| be |form|'s |contentType|.
+            </li>
+            <li>
+              Set |result|'s |encoding| to the
+              <a href="https://encoding.spec.whatwg.org/#name">encoding name</a>
+              if that is available.
+            </li>
+            <li>
+              Set |result|'s |lang| to the [=language tag=] if available.
+            </li>
+            <li>
+              Return |result|.
+            </li>
+          </ol>
         </li>
       </ol>
-      <p class="ednote">
-        These steps need to be expanded and defined in more detail.
-      </p>
     </section>
-    <section><h3>The <dfn>validate Property value</dfn> algorithm</h3>
-      To <a>validate Property value</a> given |value|, run the following steps:
+
+    <section><h3>The <dfn>create interaction data</dfn> algorithm</h3>
+      For a given <a>WoT Interaction</a> |interaction| and <a>ConsumedThing</a>
+      object |thing:ConsumedThing|, in order to <a>create interaction data</a>
+      given |data| and |form|, run these steps:
       <ol>
         <li>
-          Based on the <a href="https://www.w3.org/TR/2019/CR-wot-thing-description-20190516/#dataschema">DataSchema definition</a>, |value| MUST be a JSON value and comply to the data schema defined for the <a>Property</a> that is found in <a>Thing Description</a>.
+          If |data| is an {{InteractionData}} object, run these sub-steps:
+          <ol>
+            <li>
+              If |form|'s |contentType| and |data|'s |mediaType| are defined,
+              but not equal, throw {{SyntaxError}} and abort these steps.
+            </li>
+            <li>
+              If |data|'s |mediaType| is not defined, let it be |form|'s |contentType|.
+            </li>
+            <li>
+              Return |data| and abort these steps.
+            </li>
+          </ol>
         </li>
         <li>
-           If that fails, [= exception/throw =] a {{"SyntaxError"}} and abort these steps.
-        </li>
-        <li>
-          Return |reply|.
+          If |form|'s |type| is defined, run these sub-steps:
+          <ol>
+            <li>
+              If |type| is `"null"` and |data| is not, throw {{SyntaxError}} and abort these steps.
+            </li>
+            <li>
+              If |type| is `"boolean"` and |data| is a falsy value, let
+              |data| be `false`, otherwise `true`.
+            </li>
+            <li>
+              If |type| is `"integer"` or `"number"` and |data| is not a number,
+              or if |form|'s |minimum| is defined and |data| is smaller,
+              or if |form|'s |maximum| is defined and |data| is bigger,
+              throw {{SyntaxError}} and abort these steps.
+            </li>
+            <li>
+              If |type| is `"string"` and |data| is not a string, let |data| be
+              the result of running <a>serialize JSON to bytes</a> on |data|.
+              If that is failure, throw {{SyntaxError}} and abort these steps.
+            </li>
+            <li>
+              If |type| is `"array"`, run these sub-steps:
+              <ol>
+                <li>
+                  If |data| is not an array, throw {{SyntaxError}} and abort these steps.
+                </li>
+                <li>
+                  Let |length| be the length of |data|.
+                </li>
+                <li>
+                  If |form|'s |minItems| is defined and |length| is less than
+                  that, or if |form|'s |maxItems| is defined and |length| is
+                  more than that, throw {{SyntaxError}} and abort these steps.
+                </li>
+                <li>
+                  For each item in |data|,  |rawData| in |length| number of equal chunks. If that fails,
+                  throw {{SyntaxError}} and abort these steps.
+                </li>
+                <li>
+                  For each |item| in |data| with |index|, let |item| be the
+                  result of running these steps on |item| and |schema| obtained
+                  from |form|'s |items| at |index|. If this throws at any stage,
+                  throw {{SyntaxError}} and abort these steps.
+                </li>
+              </ol>
+            </li>
+            <li>
+              If |type| is `"object"`, run these sub-steps:
+              <ol>
+                <li>
+                  If |data| is not an object, throw {{SyntaxError}} and abort these steps.
+                </li>
+                <li>
+                  If |form|'s |properties| is not an object,
+                  throw {{SyntaxError}} and abort these steps.
+                </li>
+                <li>
+                  For each property |key| in |data|,
+                  <ol>
+                    <li>Let |value| be the value of |key|.</li>
+                    <li>Let |schema| be the value of |key| in |properties|.</li>
+                    <li>
+                      Let |value| be the result of running these steps on |value| and |schema|. If this throws, then throw {{SyntaxError}} and abort these steps.
+                    </li>
+                  </ol>
+                </li>
+                <li>
+                  If |form|'s |required| is defined, for each of its |item|
+                  check if |item| is a property in |data|. If an |item| is
+                  not found in |result|, throw {{SyntaxError}} and abort these steps.
+                </li>
+              </ol>
+            </li>
+          </ol>
         </li>
       </ol>
     </section>

--- a/index.html
+++ b/index.html
@@ -408,7 +408,11 @@
         </li>
         <li>
           Set up the <a>WoT Interactions</a> based on introspecting <a>td</a> as explained in [[!WOT-TD]] and [[!WOT-PROTOCOL-BINDINGS]]. Make a request to the underlying platform to initialize the <a>Protocol Bindings</a>.
-          The details are private to the implementations and out of scope of this specification.
+          <p class="ednote">
+            Implementations encapsulate the complexity of how to use the
+            <a>Protocol Bindings</a> for implementing <a>WoT interactions</a>.
+            In the future elements of that could be standardized.
+          </p>
         </li>
         <li>
           Resolve |promise| with |thing|.
@@ -1818,7 +1822,7 @@
           <li>
             Set up the <a>WoT Interactions</a> based on introspecting ||td||
             as explained in [[!WOT-TD]] and [[!WOT-PROTOCOL-BINDINGS]].
-            Make a request to the underlying platform to initialize the <a>Protocol Bindings</a> and then start serving external requests for <a>WoT Interactions</a> (read, write and observe <a>Properties</a>, invoke <a>Action</a>s and manage <a>Event</a> subscriptions), based on the <a>Protocol Bindings</a>. The details are private to the implementations and out of scope of this specification.
+            Make a request to the underlying platform to initialize the <a>Protocol Bindings</a> and then start serving external requests for <a>WoT Interactions</a> (read, write and observe <a>Properties</a>, invoke <a>Action</a>s and manage <a>Event</a> subscriptions), based on the <a>Protocol Bindings</a>.
           </li>
           <li>
             If there was an error during the request, reject |promise| with an {{Error}} object |error| with |error|'s |message| set to the error code seen by the <a>Protocol Bindings</a> and abort these steps.

--- a/index.html
+++ b/index.html
@@ -495,11 +495,13 @@
         Promise&lt;void&gt; observeProperty(DOMString name,
                                     WotListener listener,
                                     optional InteractionOptions options = null);
-        Promise&lt;void&gt; unobserveProperty(DOMString name);
+        Promise&lt;void&gt; unobserveProperty(DOMString name,
+                                    optional InteractionOptions options = null);
         Promise&lt;void&gt; subscribeEvent(DOMString name,
                                     WotListener listener,
                                     optional InteractionOptions options = null);
-        Promise&lt;void&gt; unsubscribeEvent(DOMString name);
+        Promise&lt;void&gt; unsubscribeEvent(DOMString name,
+                                    optional InteractionOptions options = null);
         ThingDescription getThingDescription();
       };
       dictionary InteractionOptions {
@@ -808,8 +810,8 @@
     <section>
       <h3>The <dfn>unobserveProperty()</dfn> method</h3>
       <div>
-        Makes a request for unsubscribing from <a>Property</a> value change notifications. Takes a string argument |propertyName:string| and
-        returns success or failure. The method MUST run the following steps:
+        Makes a request for unsubscribing from <a>Property</a> value change notifications. Takes a string argument |propertyName:string| and an optional {{InteractionOptions}} |options:InteractionOptions| argument.
+        It returns success or failure. The method MUST run the following steps:
         <ol>
           <li>
             Return a {{Promise}} |promise:Promise| and execute the next steps <a>in parallel</a>.
@@ -818,7 +820,8 @@
             If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
           </li>
           <li>
-            Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to stop observing the <a>Property</a> identified by |propertyName|.
+            Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to stop observing the <a>Property</a> identified by |propertyName|, with optional URI templates given in |options|'
+            {{uriVariables}}.
           </li>
           <li>
             If the request fails, reject |promise| with the error received from the <a>Protocol Bindings</a> and abort these steps.
@@ -894,7 +897,7 @@
     <section>
       <h3>The <dfn>unsubscribeEvent()</dfn> method</h3>
       <div>
-        Makes a request for unsubscribing from <a>Event</a> notifications. Takes a string argument |eventName:string| and returns success or failure. The method MUST run the following steps:
+        Makes a request for unsubscribing from <a>Event</a> notifications. Takes a string argument |eventName:string| and an optional {{InteractionOptions}} |options:InteractionOptions| argument. It returns success or failure. The method MUST run the following steps:
         <ol>
           <li>
             Return a {{Promise}} |promise:Promise| and execute the next steps <a>in parallel</a>.
@@ -903,7 +906,8 @@
             If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
           </li>
           <li>
-            Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to unsubscribe from the <a>Event</a> identified by |eventName|.
+            Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to unsubscribe from the <a>Event</a> identified by |eventName|
+            with optional URI templates given in |options|' {{uriVariables}}.
           </li>
           <li>
             If the request fails, reject |promise| with the error received from the <a>Protocol Bindings</a> and abort these steps.

--- a/index.html
+++ b/index.html
@@ -1150,12 +1150,19 @@
       Represents the data used by <a>WoT Interactions</a>.
     </p>
     <p class="ednote">
-      Previously `any` has been used for representing data that
-      could be returned by <a>WoT Interactions</a>. Data type is specified in
-      the <a>TD</a> by a <a href="https://www.w3.org/TR/2019/CR-wot-thing-description-20190516/#form">Form</a>'s `contentType`
-      and optionally a <a>DataSchema</a>.
-      This interface enables handling returned data by applications as a stream
-      or
+      As specified in [[WOT-TD]], <a>WoT interactions</a> extend <a>DataSchema</a>
+      and include a number of possible <a>Form</a>s, out of which one is selected
+      for the interaction. The
+      <a href="https://www.w3.org/TR/2019/CR-wot-thing-description-20190516/#form">
+      Form</a> contains a `contentType` to describe the data.
+      For certain content types, a <a>DataSchema</a> is defined, based on
+      <a>JSON schema</a>, making possible to represent these contents as
+      JavaScript types.
+    </p>
+    <p>
+      This interface provides automatic value parsing when a <a>DataSchema</a>
+      is available, and otherwise provide a way to parse data based on
+      content type and exposed as a stream.
     </p>
     <pre class="idl">
       [SecureContext, Exposed=(Window,Worker)]
@@ -2273,6 +2280,9 @@
     </p>
     <p>
       <dfn>JSON-LD</dfn> is defined in [[!JSON-LD]] as a JSON document that is augmented with support for Linked Data.
+    </p>
+    <p>
+      <dfn>JSON schema</dfn> is defined in <a href="https://json-schema.org/specification.html">these specifications</a>.
     </p>
     <p>
       The terms

--- a/index.html
+++ b/index.html
@@ -686,7 +686,8 @@
             </ol>
           </li>
           <li>
-            If the above step fails at any point, reject |promise| with a {{SyntaxError}} and abort these steps.
+            If the above step throws at any point, reject |promise| with that
+            exception and abort these steps.
           </li>
           <li>
             Resolve |promise| with |result|.
@@ -774,7 +775,7 @@
             If |form| is failure, reject |promise| with a {{SyntaxError}} and abort these steps.
           </li>
           <li>
-            Let |data| be the result of running the <a>create interaction data</a>steps on |value|, |form| and |interaction|. If that fails, reject <a>promise</a> with {{SyntaxError}} and abort these steps.
+            Let |data| be the result of running the <a>create interaction data</a>steps on |value|, |form| and |interaction|. If that throws, reject <a>promise</a> with that exception and abort these steps.
           </li>
           <li>
             Make a request to the underlying platform (via the <a>Protocol Bindings</a>)
@@ -838,8 +839,8 @@
             For each key |key:string| in |properties|, take its value as |value|
             and run the <a>create interaction data</a> steps on |value|, |form|
             and the value for |schema|'s |key|.
-            If that fails for any |name|, reject <a>promise</a> with a
-            {{SyntaxError}} and abort these steps.
+            If that throws for any |name|, reject <a>promise</a> with that
+            exception and abort these steps.
           </li>
           <li>
             Make a single request to the underlying platform (via the
@@ -915,7 +916,7 @@
             <ul>
               <li>
                 Let |reply| be the result of running <a>parse interaction response</a>
-                with |value|, |form| and |interaction|. If that fails, reject |promise| with a {{SyntaxError}} and abort these steps.
+                with |value|, |form| and |interaction|. If that throws, reject |promise| with that exception and abort these steps.
               </li>
               <li>
                 Invoke |listener| with |reply|.
@@ -999,7 +1000,7 @@
           </li>
           <li>
             Let |result| be the result of running <a>parse interaction response</a>
-            with |value|, |form| and |interaction|. If that fails, reject |promise| with a {{SyntaxError}} and abort these steps.
+            with |value|, |form| and |interaction|. If that throws, reject |promise| with that exception and abort these steps.
           </li>
           <li>
             Resolve |promise| with |result|.
@@ -1131,22 +1132,28 @@
         },
         10000);
 
-        function parseData(response) {
-          if (response.value !== undefined)
-            return data.value;
-          // if response.value is undefined, it means parsing has failed
-          // app can try low-level stream read
-          const reader = value.data.getReader();
-          let value = null;
+        async function parseData(response) {
+          let value = undefined;
+          try {
+            value = await response.value();
+          catch(err) {
+            // if response.value() fails, try low-level stream read
+            if (response.dataUsed)
+              return undefined;  // or make a second request
 
-          reader.read().then(function process({ done, chunk }) {
-              if (done) {
+            const reader = value.data.getReader();
+            value = null;
+
+            reader.read().then(function process({ done, chunk }) {
+                if (done) {
+                  value += chunk;
+                  return value;
+                }
                 value += chunk;
-                return value
-              }
-              value += chunk;
-              return reader.read().then(process);
-            });
+                return reader.read().then(process);
+              });
+          }
+          return value;
         };
       </pre>
     </section> <!-- Examples -->
@@ -1215,7 +1222,7 @@
         </li>
         <li>
           If |data| is not {{ReadableStream}} or if |dataUsed| is `true`,
-          reject|promise| with {{SyntaxError}} and abort these steps.
+          reject|promise| with {{NotReadableError}} and abort these steps.
         </li>
         <li>
           Let |reader| be the result of
@@ -1259,7 +1266,13 @@
           If the value of the |data| property is not a {{ReadableStream}} or if
           |dataUsed| is `true`, or if |form| is `null` or if |schema| or its
           |type| are `null` or `undefined`,
-          reject |promise| with {{SyntaxError}} and abort these steps.
+          reject |promise| with {{NotReadableError}} and abort these steps.
+        </li>
+        <li>
+          If |form|'s |contentType| is not `application/json` and if a mapping is
+          not available in the <a>Protocol Bindings</a> from |form|'s |contentType|
+          to [JSON-SCHEMA], reject |promise| with {{NotSupportedError}} and
+          abort these steps.
         </li>
         <li>
           Let |reader| be the result of
@@ -1282,7 +1295,7 @@
         </li>
         <li>
           Let |json| be the result of running <a>parse JSON from bytes</a> on
-          |bytes|. If that throws, reject |promise| with {{SyntaxError}} and
+          |bytes|. If that throws, reject |promise| with that exception and
           abort these steps.
         </li>
         <li>
@@ -1304,7 +1317,7 @@
         </li>
         <li>
           If |type| is `"null"` and if |payload| is not `null`,
-          throw {{SyntaxError}} and abort these steps, otherwise return `null`.
+          throw {{TypeError}} and abort these steps, otherwise return `null`.
         </li>
         <li>
           If |type| is `"boolean"` and |payload| is a falsey value or its byte
@@ -1314,10 +1327,11 @@
           If |type| is `"integer"` or `"number"`,
           <ol>
             <li>
-              If |payload| is not a number, throw {{SyntaxError}} and abort these steps.
+              If |payload| is not a number, throw {{TypeError}} and abort these steps.
             </li>
             <li>
-              If |form|'s |minimum| is defined and |payload| is smaller, or if |form|'s |maximum| is defined and |payload| is bigger, throw {{SyntaxError}} and abort these steps.
+              If |form|'s |minimum| is defined and |payload| is smaller, or if |form|'s |maximum| is defined and |payload| is bigger, throw
+              {{RangeError}} and abort these steps.
             </li>
           </ol>
         </li>
@@ -1328,18 +1342,18 @@
           If |type| is `"array"`, run these sub-steps:
           <ol>
             <li>
-              If |payload| is not an array, throw {{SyntaxError}} and abort these steps.
+              If |payload| is not an array, throw {{TypeError}} and abort these steps.
             </li>
             <li>
               If |form|'s |minItems| is defined and |payload|'s |length| is
               less than that, or if |form|'s |maxItems| is defined and |payload|'s
-              |length| is more than that, throw {{SyntaxError}} and abort these steps.
+              |length| is more than that, throw {{RangeError}} and abort these steps.
             </li>
             <li>
               Let |payload| be an array of items obtained by running the
               <a>check data schema</a> steps on each element |item| of |payload|
               and |schema|'s |items|.
-              If this throws at any stage, throw {{SyntaxError}} and abort these steps.
+              If this throws at any stage, re-throw that exception and abort these steps.
             </li>
           </ol>
         </li>
@@ -1348,7 +1362,7 @@
           <ol>
             <li>
               If |payload| or |schema|'s |properties| is not an object,
-              throw {{SyntaxError}} and abort these steps.
+              throw {{TypeError}} and abort these steps.
             </li>
             <li>
               For each property |key| in |payload|,
@@ -1361,7 +1375,7 @@
                 <li>
                   Let |prop| be the result of running the
                   <a>check data schema</a> steps on |prop| and |propSchema|.
-                  If this throws, then throw {{SyntaxError}} and abort these steps.
+                  If this throws, re-throw that exception and abort these steps.
                 </li>
               </ol>
             </li>
@@ -1401,7 +1415,7 @@
           <ol>
             <li>
               If |type| is `"null"` and |source| is not,
-              throw {{SyntaxError}} and abort these steps.
+              throw {{TypeError}} and abort these steps.
             </li>
             <li>
               If |type| is `"boolean"` and |source| is a falsy value, set
@@ -1411,7 +1425,7 @@
               If |type| is `"integer"` or `"number"` and |source| is not a number,
               or if |form|'s |minimum| is defined and |source| is smaller,
               or if |form|'s |maximum| is defined and |source| is bigger,
-              throw {{SyntaxError}} and abort these steps.
+              throw {{RangeError}} and abort these steps.
             </li>
             <li>
               If |type| is `"string"` and |source| is not a string, let |idata|'s
@@ -1423,7 +1437,7 @@
               If |type| is `"array"`, run these sub-steps:
               <ol>
                 <li>
-                  If |source| is not an array, throw {{SyntaxError}} and abort these steps.
+                  If |source| is not an array, throw a {{TypeError}} and abort these steps.
                 </li>
                 <li>
                   Let |length| be the length of |source|.
@@ -1431,14 +1445,14 @@
                 <li>
                   If |form|'s |minItems| is defined and |length| is less than
                   that, or if |form|'s |maxItems| is defined and |length| is
-                  more than that, throw {{SyntaxError}} and abort these steps.
+                  more than that, throw {{RangeError}} and abort these steps.
                 </li>
                 <li>
                   For each |item| in |source|, let |itemschema| be |schema|'s
                   |items| and let |item| be the result of running the
                   <a>create interaction data</a> steps on |item|, |form| and
                   |itemschema|.
-                  If this throws, throw {{SyntaxError}} and abort these steps.
+                  If this throws, re-throw that exception and abort these steps.
                 </li>
                 <li>
                   Set |data|'s [[\value]] to |source|.
@@ -1449,11 +1463,11 @@
               If |type| is `"object"`, run these sub-steps:
               <ol>
                 <li>
-                  If |source| is not an object, throw {{SyntaxError}} and abort these steps.
+                  If |source| is not an object, throw {{TypeError}} and abort these steps.
                 </li>
                 <li>
                   If |schema|'s |properties| is not an object,
-                  throw {{SyntaxError}} and abort these steps.
+                  throw {{TypeError}} and abort these steps.
                 </li>
                 <li>
                   For each property |key| in |source|,
@@ -1464,7 +1478,7 @@
                       Let |value| be the result of running the
                       <a>create interaction data</a> steps on |value|, |form|
                       and |propschema|.
-                      If this throws, then throw {{SyntaxError}} and abort these steps.
+                      If this throws, re-throw that exception and abort these steps.
                     </li>
                   </ol>
                 </li>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>Web of Things (WoT) Scripting API</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
+    <script src='https://www.w3.org/Tools/respec/respec-w3c'
+            async class='remove'></script>
     <script class='remove'>
       // See https://github.com/w3c/respec/wiki/ for how to configure ReSpec
       var respecConfig = {
@@ -465,7 +466,6 @@
       </ol>
     </div>
   </section>
-
 </section>
 
   <section data-dfn-for="ConsumedThing">
@@ -478,7 +478,7 @@
       [SecureContext, Exposed=(Window,Worker)]
       interface ConsumedThing {
         constructor(ThingDescription td);
-        Promise&lt;any&gt; readProperty(DOMString propertyName,
+        Promise&lt;InteractionData&gt; readProperty(DOMString propertyName,
                                   optional InteractionOptions options = null);
         Promise&lt;PropertyMap&gt; readAllProperties(optional InteractionOptions options = null);
         Promise&lt;PropertyMap&gt; readMultipleProperties(
@@ -489,7 +489,7 @@
                                     optional InteractionOptions options = null);
         Promise&lt;void&gt; writeMultipleProperties(PropertyMap valueMap,
                                     optional InteractionOptions options = null);
-        Promise&lt;any&gt; invokeAction(DOMString actionName,
+        Promise&lt;InteractionData&gt; invokeAction(DOMString actionName,
                                     optional any params = null,
                                     optional InteractionOptions options = null);
         Promise&lt;void&gt; observeProperty(DOMString name,
@@ -509,7 +509,7 @@
         object uriVariables;
       };
       typedef object PropertyMap;
-      callback WotListener = void(any data);
+      callback WotListener = void(InteractionData data);
     </pre>
 
     <section>
@@ -613,9 +613,13 @@
                 Based on the <a href="https://www.w3.org/TR/2019/CR-wot-thing-description-20190516/#dataschema">DataSchema definition</a>, |value| MUST be a JSON value and comply to the data schema defined for the <a>Property</a> that is found in <a>Thing Description</a>. If this fails, [= exception/throw =] a {{"SyntaxError"}} and abort these sub-steps.
               </li>
               <li>
-                Return |value|.
+                Return |reply|.
               </li>
             </ol>
+          </li>
+          <li>
+            Let |reply| be the result of running <a>create reply data</a>
+            with |value|. If that fails, reject |promise| with a {{SyntaxError}} and abort these steps.
           </li>
           <li>
             If these above sub-steps failed, reject |promise| with
@@ -649,7 +653,8 @@
             If this cannot be done with a single request with the <a>Protocol Bindings</a> of the <a>Thing</a>, then reject |promise| with a {{NotSupportedError}} and abort these steps.
           </li>
           <li>
-            Process the reply and update all properties in |result| with the values obtained in the reply.
+            Process the reply and update all properties in |result| with the
+            result of running <a>create reply data</a> on the values obtained in the reply.
           </li>
           <li>
             If the above step fails at any point, reject |promise| with a {{SyntaxError}} and abort these steps.
@@ -683,6 +688,12 @@
           </li>
           <li>
             Process the reply and let |result:object| be an object with the keys and values obtained in the reply.
+          </li>
+          <li>
+            For each |key| in |result| having its value |value|, update |value|
+            with the result of running <a>create reply data</a> with |value|.
+            If that fails, reject |promise| with a {{SyntaxError}} and abort
+            these steps.
           </li>
           <li>
             Resolve |promise| with |result|.
@@ -799,7 +810,11 @@
                 If running the <a>validate Property value</a> steps on |value| fails, abort these steps.
               </li>
               <li>
-                Invoke |listener| with |value| as parameter.
+                Let |reply| be the result of running <a>create reply data</a>
+                with |value|. If that fails, reject |promise| with a {{SyntaxError}} and abort these steps.
+              </li>
+              <li>
+                Invoke |listener| with |reply| as parameter.
               </li>
             </ul>
           </li>
@@ -854,7 +869,11 @@
             Otherwise let |value| be the result returned in the reply and run the <a>validate Property value</a> steps on it. If that fails, reject |promise| with a {{SyntaxError}} and abort these steps.
           </li>
           <li>
-            Reject |promise| with |value|.
+            Let |reply| be the result of running <a>create reply data</a>
+            with |value|. If that fails, reject |promise| with a {{SyntaxError}} and abort these steps.
+          </li>
+          <li>
+            Resolve |promise| with |reply|.
           </li>
         </ol>
       </div>
@@ -887,8 +906,7 @@
           </li>
           <li>
             Whenever the underlying platform receives a notification for this <a>Event</a> subscription, implementations SHOULD invoke
-            |listener|, giving the data provided with the <a>Event</a>
-            as parameter.
+            |listener| with the result of running <a>create reply data</a> on the data provided with the <a>Event</a>.
           </li>
         </ol>
       </div>
@@ -936,11 +954,15 @@
         try {
           // subscribe to property change for “temperature”
           await thing.observeProperty("temperature", value => {
-            console.log("Temperature changed to: " + value);
+            const decoder = new TextDecoder();
+            const data = JSON.parse(decoder.decode(value.data));
+            console.log("Temperature changed to: " + data);
           });
           // subscribe to the “ready” event defined in the TD
           await thing.subscribeEvent("ready", eventData => {
-            console.log("Ready; index: " + eventData);
+            const decoder = new TextDecoder();
+            const data = JSON.parse(decoder.decode(value.data));
+            console.log("Ready; index: " + data);
             // run the “startMeasurement” action defined by TD
             await thing.invokeAction("startMeasurement", { units: "Celsius" });
             console.log("Measurement started.");
@@ -957,6 +979,93 @@
       </pre>
     </section> <!-- Examples -->
   </section> <!-- ConsumedThing -->
+
+  <section data-dfn-for="InteractionData">
+    <h2>The <dfn>InteractionData</dfn> interface</h2>
+    <p>
+      Represents the data returned by <a>WoT Interactions</a>. Belongs to the
+      <a>WoT Consumer</a> conformance class.
+    </p>
+    <p class="ednote">
+      Previously `any` has been used for representing data that
+      could be returned by <a>WoT Interactions</a>. Since data type can be
+      specified in the <a>TD</a> by a <a href="https://www.w3.org/TR/2019/CR-wot-thing-description-20190516/#form">Form</a>'s `contentType`
+      and optionally a <a>DataSchema</a>,
+      this interface enables handling returned data by applications.
+    </p>
+    <pre class="idl">
+      [SecureContext, Exposed=(Window,Worker)]
+      interface InteractionData {
+        readonly attribute DataView? data;
+        readonly attribute USVString? mediaType;
+        readonly attribute USVString? encoding;
+        readonly attribute USVString? lang;
+        readonly attribute DataSchema? dataSchema;
+      };
+    </pre>
+    <p>
+      The <dfn>data</dfn> property represents the returned payload from
+      <a>WoT Interactions</a>.
+    </p>
+    <p>
+      The <dfn>encoding</dfn> attribute represents the
+      <a href="https://encoding.spec.whatwg.org/#name">encoding name</a> used
+      for encoding the payload in the case it is textual data.
+    </p>
+    <p>
+      The <dfn>lang</dfn> attribute represents the [=language tag=]
+      of the payload in the case that was encoded.
+    </p>
+    <p>
+      A <dfn>language tag</dfn> is a <a>string</a> that matches the
+      production of a <code>Language-Tag</code> defined in the [[BCP47]]
+      specifications (see the <a href=
+      "http://www.iana.org/assignments/language-subtag-registry">IANA
+      Language Subtag Registry</a> for an authoritative list of possible
+      values).
+    </p>
+    <p>
+      The <dfn>dataSchema</dfn> attribute represents the <a>DataSchema</a>
+      of the payload when it is different from the one defined in the
+      <a>Thing Description</a>. If the value is `null`, then the `DataSchema`
+      of the <a>WoT Interaction</a> SHOULD be fetched from the <a>TD</a>.
+    </p>
+    <section><h3>The <dfn>create reply data</dfn> algorithm</h3>
+      For a given <a>WoT Interaction</a> |interaction| and <a>ConsumedThing</a>
+      object |thing:ConsumedThing|, in order to <a>create reply data</a>
+      given the |rawData| argument, run these steps:
+      <ol>
+        <li>
+          Let |result| be a new {{InteractionData}} object with all its properties
+          set to `null`.
+        </li>
+        <li>
+          Let |result|'s |data| be a new {{DataView}} created from |rawData|.
+        </li>
+        <li>
+          If |thing|'s <a>internal slot</a> ||td|| is not defined,
+          return |result| and abort these steps.
+        </li>
+        <li>
+          Let |form:Form| be the <a>Form</a> used for |interaction|.
+        </li>
+        <li>
+          Let |result|'s |mediaType| be |form|'s |contentType|.
+        </li>
+        <li>
+          If |rawData| is text, set |result|'s |encoding| to the text encoding
+          value of |rawData| and set |result|'s |lang| to the [=language tag=]
+          associated with |rawData|.
+        </li>
+        <li>
+          Return |result|.
+        </li>
+      </ol>
+      <p class="ednote">
+        These steps need to be expanded and defined in more detail.
+      </p>
+    </section>
+  </section>
 
   <section data-dfn-for="ExposedThing">
     <h2>The <dfn>ExposedThing</dfn> interface</h2>
@@ -1822,7 +1931,9 @@
 
   <section> <h2>Terminology and conventions</h2>
     <p>
-      The generic WoT terminology is defined in [[!WOT-ARCHITECTURE]]: <dfn data-lt="Things">Thing</dfn>, <dfn data-lt="Thing Descriptions">Thing Description</dfn> (in short <dfn>TD</dfn>), <dfn>Web of Things</dfn> (in short <b><i>WoT</i></b>),  <dfn>WoT Interface</dfn> (same as <dfn>WoT network interface</dfn>), <dfn>Protocol Bindings</dfn>, <dfn>WoT Runtime</dfn>, <dfn data-lt="consume|consume a TD|consuming a TD">Consuming a Thing Description</dfn>, <dfn>Thing Directory</dfn>, <dfn>WoT Interactions</dfn>, <dfn data-lt="Properties">Property</dfn>, <dfn data-lt="Actions">Action</dfn>, <dfn data-lt="Events|WoT-Event">Event</dfn> etc.
+      The generic WoT terminology is defined in [[!WOT-ARCHITECTURE]]: <dfn data-lt="Things">Thing</dfn>, <dfn data-lt="Thing Descriptions">Thing Description</dfn> (in short <dfn>TD</dfn>), <dfn>Web of Things</dfn> (in short <b><i>WoT</i></b>),  <dfn>WoT Interface</dfn> (same as <dfn>WoT network interface</dfn>), <dfn>Protocol Bindings</dfn>, <dfn>WoT Runtime</dfn>, <dfn data-lt="consume|consume a TD|consuming a TD">Consuming a Thing Description</dfn>, <dfn>Thing Directory</dfn>, <dfn>WoT Interactions</dfn>, <dfn data-lt="Properties">Property</dfn>, <dfn data-lt="Actions">Action</dfn>, <dfn data-lt="Events|WoT-Event">Event</dfn>,
+      <a href="https://www.w3.org/TR/wot-thing-description/#dataschema">
+        <dfn>DataSchema</dfn></a>, <a href="https://www.w3.org/TR/wot-thing-description/#form"><dfn>Form</dfn></a> etc.
     </p>
     <p>
       <dfn>JSON-LD</dfn> is defined in [[!JSON-LD]] as a JSON document that is augmented with support for Linked Data.
@@ -1879,7 +1990,7 @@
       <dfn data-cite="!HTML#global-object">global object</dfn>,
       <dfn data-cite="!HTML#current-settings-object">current settings object</dfn>,
       executing algorithms <dfn data-cite="!HTML#in-parallel">in parallel</dfn>
-       are defined in [[!HTML5]] and are used in the context of browser implementations.
+       are defined in [[!HTML5]] and are used in the context of browser implementations.[=language tag=]
     </p>
     <p>
       The term


### PR DESCRIPTION
Add InteractionOptions to `unobserveProperty()` and `unsubscribeEvent()`. Addresses #201 

Add `InteractionData` definition, usage and examples. Addresses #208


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/zolkis/wot-scripting-api/pull/209.html" title="Last updated on Jun 1, 2020, 5:36 PM UTC (45b888a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/209/8037a79...zolkis:45b888a.html" title="Last updated on Jun 1, 2020, 5:36 PM UTC (45b888a)">Diff</a>