### PR TITLE
docs: minor typos/issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -1529,7 +1529,7 @@
             If |form| is failure, reject |promise| with a {{SyntaxError}} and abort these steps.
           </li>
           <li>
-            Let |args| be the result of running the <a>create interaction data</a>steps on |params|, |form| and |interaction|. If that throws, reject <a>promise</a> with that exception and abort these steps.
+            Let |args| be the result of running the <a>create interaction data</a> steps on |params|, |form| and |interaction|. If that throws, reject <a>promise</a> with that exception and abort these steps.
           </li>
           <li>
             Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to invoke the <a>Action</a> identified by |actionName| with parameters provided in |args| and optional URI templates given in |options|'s |uriVariables|.
@@ -1934,7 +1934,7 @@
       </div>
     </section>
 
-    <section> <h3>Handling requests for reading multiple Poperties</h3>
+    <section> <h3>Handling requests for reading multiple Properties</h3>
       <div>
         When a network request for reading multiple <a>Properties</a> given in
         an object |propertyNames| is received with |options:InteractionOptions|,
@@ -1954,7 +1954,7 @@
               <li>
                 Let |value| be the result of running the <a>read server property</a>
                 steps on |name| and |options|.
-                If that throws, send back the error in the reply created by following the  <a>Protocol Bindings</a>and abort these steps.
+                If that throws, send back the error in the reply created by following the  <a>Protocol Bindings</a> and abort these steps.
               </li>
               <li>
                 Set the value of |propertyNames|'s |name| to |value|.
@@ -2216,7 +2216,7 @@
       <p>
         There MUST be at most one write handler for any given <a>Property</a>, so newly added handlers MUST replace the previous handlers. If no write handler is initialized for any given <a>Property</a>, implementations SHOULD implement default property update if the <a>Property</a> is
         writeable and notifying observers on change if the <a>Property</a> is
-        observeable, based on the <a>Thing Description</a>.
+        observable, based on the <a>Thing Description</a>.
       </p>
       <div>
         When the method is invoked given |name:string| and
@@ -2435,7 +2435,7 @@
       <p>
         A function that is called when an external request for subscribing to an
         <a>Event</a> is received and defines what to do with such requests.
-        It is invoked with a |options:InteractionOptions| object provided by the implementation and coming from subscribers.
+        It is invoked with an |options:InteractionOptions| object provided by the implementation and coming from subscribers.
         It returns a {{Promise}} that rejects with an error or resolves when
         the subscription is accepted.
       </p>
@@ -2931,7 +2931,7 @@
       The <dfn>done</dfn> property is `true` if the discovery has been completed with no more results to report and <a>discovery results</a> is also empty.
     </p>
     <p>
-      The <dfn>error</dfn> property represents the last error that occured during the discovery process. Typically used for critical errors that stop discovery.
+      The <dfn>error</dfn> property represents the last error that occurred during the discovery process. Typically used for critical errors that stop discovery.
     </p>
 
     <section><h3>Constructing {{ThingDiscovery}}</h3>


### PR DESCRIPTION
# 7.13 The invokeAction() method

Point 6: "create interaction datasteps" --> "create interaction data steps"

# 8.6 Handling requests for reading multiple Poperties

Typo in header: "Poperties" --> "Properties"

Point 6, "Protocol Bindingsand" --> "Protocol Bindings and"

# 8.13 The setPropertyWriteHandler() method

"observeable" --> "observable"

# 8.20 The EventSubscriptionHandler callback

"with a options object" --> "with an options object "

# 9. The ThingDiscovery interface

"occured" --> "occurred"


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/pull/229.html" title="Last updated on Aug 3, 2020, 1:37 PM UTC (b1d5240)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/229/f7eef4c...b1d5240.html" title="Last updated on Aug 3, 2020, 1:37 PM UTC (b1d5240)">Diff</a>