### PR TITLE
Add more Consume Thing examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -1687,7 +1687,7 @@
       <p>
         The next example illustrates how to fetch a <a>TD</a> by URL, create a {{ConsumedThing}}, read metadata (title), read property value, subscribe to property change, subscribe to a WoT event, unsubscribe.
       </p>
-      <pre class="example" title="Thing Client API example">
+      <pre class="example" title="Thing Client API example with data value">
         try {
           let res = await fetch("https://tds.mythings.org/sensor11");
           let td = res.json();
@@ -1739,7 +1739,7 @@
       <p>
         The following shows an advance usage of {{InteractionOutput}} to read a property without a {{DataSchema}}.
       </p>
-      <pre class="example" title="Client ArrayBuffer example">
+      <pre class="example" title="Thing Client API example with arrayBuffer">
         /*
         * takePicture affordance form:
         * "form": {
@@ -1754,10 +1754,10 @@
         */
         let response;
         let image;
-        try{
+        try {
           response = await thing.invokeAction(“takePicture”));
           image = await response.value() // throws NotReadableError --> schema not defined
-        }catch(ex){
+        } catch(ex) {
           image = await response.arrayBuffer();
           // image: ArrayBuffer [0x1 0x2 0x3 0x5 0x15 0x23 ...]
         }
@@ -1765,7 +1765,7 @@
       <p>
         Finally, the next two examples shows the usage of a {{ReadableStream}} from an {{InteractionOutput}}.
       </p>
-      <pre class="example" title="Thing Client video streaming example">
+      <pre class="example" title="Thing Client API example with readable stream (e.g., video stream)">
         /*{
         "video": {
           "description" : "the video stream of this camera",
@@ -1795,7 +1795,7 @@
       <p>Here consider that the JSON object is too big to be read wholly in the memory. Therefore,
         we use streaming processing to get the total number of the events recorded by the remote Web Thing.
       </p>
-      <pre class="example" title="Client streaming processing: counting json objects">
+      <pre class="example" title="Thing Client API example with readable stream (e.g., counting json objects)">
         /*
         * "eventHistory":
         * {

--- a/index.html
+++ b/index.html
@@ -1736,6 +1736,92 @@
           }
         }, 10000);
       </pre>
+      <p>
+        The following shows an advance usage of {{InteractionOutput}} to read a property without a {{DataSchema}}.
+      </p>
+      <pre class="example" title="Client ArrayBuffer example">
+        /*
+        * takePicture affordance form:
+        * "form": {
+        *   "op": "invokeaction",
+        *   "href" : "http://camera.example.com:5683/takePicture",
+        *   "response": {
+        *     "contentType": "image/jpeg",
+        *     "contentCoding": "gzip"
+        *   }
+        *}
+        * See https://www.w3.org/TR/wot-thing-description/#example-23
+        */
+        let response;
+        let image;
+        try{
+          response = await thing.invokeAction(“takePicture”));
+          image = await response.value() // throws NotReadableError --> schema not defined
+        }catch(ex){
+          image = await response.arrayBuffer();
+          // image: ArrayBuffer [0x1 0x2 0x3 0x5 0x15 0x23 ...]
+        }
+      </pre>
+      <p>
+        Finally, the next two examples shows the usage of a {{ReadableStream}} from an {{InteractionOutput}}.
+      </p>
+      <pre class="example" title="Thing Client video streaming example">
+        /*{
+        "video": {
+          "description" : "the video stream of this camera",
+          "forms": [
+            {
+              "op": "readproperty",
+              "href": "http://camera.example.com/live",
+              "subprotocol": "hls"
+              "contentType": "video/mp4"
+            }
+          ]
+        }}*/
+
+        const video = await thing.readProperty("video")
+        const reader = video.data.getReader()
+        reader.read().then(function processVideo({ done, value }) {
+          if (done) {
+            console.log("live video stoped");
+            return;
+          }
+          const decoded = decode(value)
+          UI.show(decoded)
+          // Read some more, and call this function again
+          return reader.read().then(processText);
+        });
+      </pre>
+      <p>Here consider that the JSON object is too big to be read wholly in the memory. Therefore,
+        we use streaming processing to get the total number of the events recorded by the remote Web Thing.
+      </p>
+      <pre class="example" title="Client streaming processing: counting json objects">
+        /*
+        * "eventHistory":
+        * {
+        *   "description" : "A long list of the events recorderd by this thing",
+        *   "type": "array",
+        *   "forms": [
+        *     {
+        *       "op": "readproperty",
+        *       "href": "http://recorder.example.com/eventHistory",
+        *     }
+        *   ]
+        * }
+        */
+
+        // Example of streaming processing: counting json objects
+        let objectCounter = 0
+        const parser = new Parser() //User library for json streaming parsing (i.e. https://github.com/uhop/stream-json/wiki/Parser)
+        
+        parser.on('data', data => data.name === 'startObject' && ++objectCounter);
+        parser.on('end', () => console.log(`Found ${objectCounter} objects.`));
+        
+        const response = await thing.readProperty(“eventHistory”)
+        await response.data.pipeTo(parser);
+
+        // Found N objects
+      </pre>
     </section> <!-- Examples -->
   </section> <!-- ConsumedThing -->
 


### PR DESCRIPTION
As the title says this PR adds three examples to the Consume Thing object. In particular, the examples show usages of `arrayBuffer` and `ReadableStream`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/relu91/wot-scripting-api/pull/257.html" title="Last updated on Aug 31, 2020, 3:23 PM UTC (d39bbd3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/257/05c3eaf...relu91:d39bbd3.html" title="Last updated on Aug 31, 2020, 3:23 PM UTC (d39bbd3)">Diff</a>