### PR TITLE
Fix #244: ConsumeThing constructor and consume() should do the same

### DIFF
--- a/index.html
+++ b/index.html
@@ -415,9 +415,6 @@
           If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
         </li>
         <li>
-          Run the <a>validate a TD</a> steps on |td|. If that fails, reject |promise| with {{SyntaxError}} and abort these steps.
-        </li>
-        <li>
           Let |thing:ConsumedThing| be a new {{ConsumedThing}} object constructed from |td|.
         </li>
         <li>
@@ -1053,6 +1050,10 @@
         To create {{ConsumedThing}} with the {{ThingDescription}}
         |td:ThingDescription|, run the following steps:
         <ol>
+          <li>
+            Run the <a>validate a TD</a> steps on |td|. If that fails,
+            [= exception/throw =] {{SyntaxError}} and abort these steps.
+          </li>
           <li>
             Run the <a>expand a TD</a> steps on |td|. If that fails, re-[= exception/throw =] the error and abort these steps.
           </li>
@@ -1696,7 +1697,7 @@
         } catch (e) {
           console.log("TD fetch error: " + e.message);
         };
-        
+
         try {
           // subscribe to property change for “temperature”
           await thing.observeProperty("temperature", async (data) => {
@@ -1722,13 +1723,13 @@
         } catch (e) {
           console.log("Error starting measurement.");
         }
-        
+
         setTimeout(async () => {
           try {
             const temperatureData = await thing.readProperty("temperature")
             const temperature = await temperatureData.value();
             console.log("Temperature: " + temperature);
-        
+
             await thing.unsubscribe("ready");
             console.log("Unsubscribed from the ‘ready’ event.");
           } catch (error) {
@@ -1813,10 +1814,10 @@
         // Example of streaming processing: counting json objects
         let objectCounter = 0
         const parser = new Parser() //User library for json streaming parsing (i.e. https://github.com/uhop/stream-json/wiki/Parser)
-        
+
         parser.on('data', data => data.name === 'startObject' && ++objectCounter);
         parser.on('end', () => console.log(`Found ${objectCounter} objects.`));
-        
+
         const response = await thing.readProperty(“eventHistory”)
         await response.data.pipeTo(parser);
 

--- a/index.html
+++ b/index.html
@@ -429,6 +429,12 @@
           Resolve |promise| with |thing|.
         </li>
       </ol>
+      <p class="ednote">
+        Note the difference between constructing <a>ConsumedThing</a> and using
+        the <code>consume()</code> method: the latter also initializes the protocol
+        bindings, whereas a simple constructed object will not have <a>WoT Interactions</a>
+        initialized until they are invoked.
+      </p>
     </div>
   </section>
 


### PR DESCRIPTION
WiP:
- moved one clause from consume() to ConsumedThing constructor
- however, binding initialization step is problematic in constructor.

Signed-off-by: Zoltan Kis <zoltan.kis@intel.com>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/zolkis/wot-scripting-api/pull/259.html" title="Last updated on Sep 14, 2020, 2:23 PM UTC (c9ee6a8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/259/c8ae596...zolkis:c9ee6a8.html" title="Last updated on Sep 14, 2020, 2:23 PM UTC (c9ee6a8)">Diff</a>