### PR TITLE
Fix typescript definition module name

### DIFF
--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -295,6 +295,6 @@ declare namespace WoT {
 
 }
 
-declare module "WoT" {
+declare module "wot-typescript-definitions" {
     export = WoT;
 }


### PR DESCRIPTION
As pointed by @danielpeintner in this comment: https://github.com/w3c/wot-scripting-api/pull/265#issuecomment-698334103, our fight with typescript definition file has not ended. This PR should fix the issue reported in the comment. Plus we'll probably write a warning saying that this file definition is only valid for ES6 and above. 