### PR TITLE
Add editor's note about WoT interactions vs Interaction Affordances

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,10 +122,6 @@
       This specification is implemented at least by the <a href="http://www.thingweb.io/">Eclipse Thingweb</a>
       project also known as <a href="https://github.com/eclipse/thingweb.node-wot">node-wot</a>, which is considered the reference open source implementation at the moment. Check its <a href="https://github.com/eclipse/thingweb.node-wot"> source code</a>, including <a href="https://github.com/eclipse/thingweb.node-wot/examples">examples</a>.
     </p>
-    <p class="ednote" title="WoT Interaction vs Interaction Affordance">
-      <a>Interaction Affordance</a> it is the correct term when referring Thing capabilities (as explain <a href="https://github.com/w3c/wot-thing-description/issues/282">here</a>). 
-      However, this term is not well understood inside the developers community. Therefore, for the sake of the readability, this document and this API will use the term <a>WoT interaction</a> or, simply, interaction instead. 
-    </p>
   </section>
 
   <section id="sotd">
@@ -3664,7 +3660,13 @@
         <dfn>DataSchema</dfn></a>, <a href="https://www.w3.org/TR/wot-thing-description/#form"><dfn>Form</dfn></a> etc.
     </p>
     <p>
-      <dfn data-plurals="WoT Interactions">WoT Interaction</dfn> is a synonym of <a href="https://w3c.github.io/wot-architecture/#dfn-interaction-affordance"><dfn>Interaction Affordance</dfn></a>
+      <dfn data-plurals="WoT Interactions">WoT Interaction</dfn> is a synonym for <a href="https://w3c.github.io/wot-architecture/#dfn-interaction-affordance"><dfn>Interaction Affordance</dfn></a>.
+      An <a>Interaction Affordance</a> (or shortly, affordance) is the term used in [[!WOT-TD]]
+      when referring to <a>Thing</a> capabilities, as explained in
+      <a href="https://github.com/w3c/wot-thing-description/issues/282">TD issue 282</a>.
+      However, this term is not well understood outside the <a>TD</a> semantic context.
+      Hence for the sake of readability, this document will use the previous term
+      <a>WoT interaction</a> or, simply, <em>interaction</em> instead.
     </p>
     <p>
       <dfn>JSON-LD</dfn> is defined in [[!JSON-LD]] as a JSON document that is augmented with support for Linked Data.

--- a/index.html
+++ b/index.html
@@ -122,6 +122,10 @@
       This specification is implemented at least by the <a href="http://www.thingweb.io/">Eclipse Thingweb</a>
       project also known as <a href="https://github.com/eclipse/thingweb.node-wot">node-wot</a>, which is considered the reference open source implementation at the moment. Check its <a href="https://github.com/eclipse/thingweb.node-wot"> source code</a>, including <a href="https://github.com/eclipse/thingweb.node-wot/examples">examples</a>.
     </p>
+    <p class="ednote" title="WoT Interaction vs Interaction Affordance">
+      <a>Interaction Affordance</a> it is the correct term when referring Thing capabilities (as explain <a href="https://github.com/w3c/wot-thing-description/issues/282">here</a>). 
+      However, this term is not well understood inside the developers community. Therefore, for the sake of the readability, this document and this API will use the term <a>WoT interaction</a> or, simply, interaction instead. 
+    </p>
   </section>
 
   <section id="sotd">
@@ -3655,9 +3659,12 @@
 
   <section> <h2>Terminology and conventions</h2>
     <p>
-      The generic WoT terminology is defined in [[!WOT-ARCHITECTURE]]: <dfn data-lt="Things">Thing</dfn>, <dfn data-lt="Thing Descriptions">Thing Description</dfn> (in short <dfn>TD</dfn>), <dfn>Web of Things</dfn> (in short <b><i>WoT</i></b>),  <dfn>WoT Interface</dfn> (same as <dfn>WoT network interface</dfn>), <dfn>Protocol Bindings</dfn>, <dfn>WoT Runtime</dfn>, <dfn data-lt="consume|consume a TD|consuming a TD">Consuming a Thing Description</dfn>, <dfn>Thing Directory</dfn>, <dfn>WoT Interactions</dfn>, <dfn data-lt="Properties">Property</dfn>, <dfn data-lt="Actions">Action</dfn>, <dfn data-lt="Events|WoT-Event">Event</dfn>,
+      The generic WoT terminology is defined in [[!WOT-ARCHITECTURE]]: <dfn data-lt="Things">Thing</dfn>, <dfn data-lt="Thing Descriptions">Thing Description</dfn> (in short <dfn>TD</dfn>), <dfn>Web of Things</dfn> (in short <b><i>WoT</i></b>),  <dfn>WoT Interface</dfn> (same as <dfn>WoT network interface</dfn>), <dfn>Protocol Bindings</dfn>, <dfn>WoT Runtime</dfn>, <dfn data-lt="consume|consume a TD|consuming a TD">Consuming a Thing Description</dfn>, <dfn>Thing Directory</dfn>, <dfn data-lt="Properties">Property</dfn>, <dfn data-lt="Actions">Action</dfn>, <dfn data-lt="Events|WoT-Event">Event</dfn>,
       <a href="https://www.w3.org/TR/wot-thing-description/#dataschema">
         <dfn>DataSchema</dfn></a>, <a href="https://www.w3.org/TR/wot-thing-description/#form"><dfn>Form</dfn></a> etc.
+    </p>
+    <p>
+      <dfn data-plurals="WoT Interactions">WoT Interaction</dfn> is a synonym of <a href="https://w3c.github.io/wot-architecture/#dfn-interaction-affordance"><dfn>Interaction Affordance</dfn></a>
     </p>
     <p>
       <dfn>JSON-LD</dfn> is defined in [[!JSON-LD]] as a JSON document that is augmented with support for Linked Data.


### PR DESCRIPTION
As the title says, this PR attempts to clarify the usage of WoT Interaction instead of Interaction Affordances. I added both an Editor's and a term definition inside section 11. Please let me know if it can be improved.

Fixes #241


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/relu91/wot-scripting-api/pull/272.html" title="Last updated on Oct 13, 2020, 4:12 PM UTC (b9a513e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/272/3592d77...relu91:b9a513e.html" title="Last updated on Oct 13, 2020, 4:12 PM UTC (b9a513e)">Diff</a>