### PR TITLE
update WOT references to latest publication URL/date

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,28 +54,22 @@
         xref: ["web-platform", "streams", "wot-architecture", "wot-thing-description", "wot-binding-templates"],
         localBiblio: {
           "WOT-ARCHITECTURE" : {
-            href:"https://www.w3.org/TR/2019/CR-wot-architecture-20190516/",
+            href:"https://www.w3.org/TR/2020/REC-wot-architecture-20200409/",
             title: "Web of Things Architecture",
             publisher: "W3C",
-            date: "16 May 2019"
+            date: "9 April 2020"
           },
           "WOT-TD" : {
-            href:"https://www.w3.org/TR/2019/CR-wot-thing-description-20190516/",
-            title: "WoT Thing Description ",
+            href:"https://www.w3.org/TR/2020/REC-wot-thing-description-20200409/",
+            title: "Web of Things Thing Description",
             publisher: "W3C",
-            date: "16 May 2019"
+            date: "9 April 2020"
           },
           "WOT-PROTOCOL-BINDINGS" : {
             href:"https://w3c.github.io/wot-binding-templates/",
-            title: "Web of Things Protocol Binding Templates",
+            title: "Web of Things Binding Templates",
             publisher: "W3C",
-            date: "20 August 2017"
-          },
-          "WOT-PRACTICES": {
-            href:"http://w3c.github.io/wot/current-practices/wot-practices.html",
-            title: "Web of Things Current Practices",
-            publisher: "W3C",
-            date: "6 February 2017"
+            date: "22 July 2020"
           },
           "WOT-SECURITY" : {
             href: "https://w3c.github.io/wot-security/",


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-scripting-api/pull/276.html" title="Last updated on Oct 19, 2020, 12:17 PM UTC (4449710)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/276/94d9028...danielpeintner:4449710.html" title="Last updated on Oct 19, 2020, 12:17 PM UTC (4449710)">Diff</a>