### PR TITLE
Add definitions for partialTD

### DIFF
--- a/index.html
+++ b/index.html
@@ -484,7 +484,7 @@
         <li>Search for missing required properties in |td| accordingly to
           <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#json-schema-for-validation">TD JSON
             Schema</a>.
-          (TODO: possibly expand this step)
+          <p class="ednote">The editors find this step vague. It will be improved or removed in the next iteration. </p>
         </li>
         <li>For each |missing| property run these sub-steps:
           <ol>
@@ -492,10 +492,13 @@
             <li>If |missing| is <code>@context</code> assign the latest supported Thing Description context URI.</li>
             <li>If |missing| is <code>instance</code> assign the string <code>1.0.0</code>.</li>
             <li>If |missing| is <code>forms</code> generate a list of <a>Forms</a> using the available <a>Protocol Bindings</a> and content types
-              encoders. Then assign the obtained list to <code>forms</code>. (TODO: expand?)</li>
+              encoders. Then assign the obtained list to <code>forms</code>.</li>
             <li>If |missing| is <code>security</code> assign the label of the first supported <a>SecurityScheme</a> in <code>securityDefinitions</code> field. 
             If no <a>SecurityScheme</a> is found generate a <a>NoSecurityScheme</a> called <code>nosec</code> and assing the string <code>nosec</code>
-          to <code>security</code>. (TODO: ask for guidance to Security task force)  </li>
+          to <code>security</code>. 
+          <p class="issue">The discussion about how to properly generate a value for <code>security</code> is still open. 
+            See issue <a href="https://github.com/w3c/wot-scripting-api/issues/299">#299</a> </p>
+          </li>
             <li>If |missing| is <code>href</code> define |formStub| as the partial <a>Form</a> that does not have <code>href</code>. Generate a valid |url:URL| using the first <a>Protocol Binding</a> 
               that satisfy the requirements of |formStub|. Assign |url| to <code>href</code>. If not <a>Protocol Binding</a> can be found remove |formStub| from |td|. </li>
             <li>Add |missing| to |td| with |value| as value</li>

--- a/index.html
+++ b/index.html
@@ -515,7 +515,7 @@
       To <dfn>expand an ExposedThingInit</dfn> given |init:ExposedThingInit| and obtain a valid |td:ThingDescription| as
       a result,
       run the following steps:
-      <ol>
+      <ol class="algorithm">
         <li>Run <a>validate an ExposedThingInit</a> on |init|. If that fails,
           [= exception/throw =] {{SyntaxError}} and abort these steps.</li>
         <li>Initialize and empty object called |td|</li>
@@ -570,7 +570,7 @@
     <section>
       <h3>Validating an ExposedThingInit</h3>
       To <dfn>validate an ExposedThingInit</dfn> given |init:ExposedThingInit|, run the following steps:
-      <ol>
+      <ol  class="algorithm">
         <li>
           Parse <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#json-schema-for-validation">TD JSON
             Schema</a>
@@ -585,8 +585,8 @@
             <li>if |key| |value| is a <code>string</code> then if |value| is equal to one of the elements in |optional| remove |key| from |exposedThingInitSchema|</li>
           </ol>
         </li>
-        <li>Return the result of <a>validating</a> |init| with |exposedThingInitSchema|
-          <p class="ednote"><dfn>Validating</dfn> steps are still under discussion.
+        <li>Return the result of <a>validating an object with JSON Schema</a> given |init| and |exposedThingInitSchema|. 
+          <p class="ednote">The<dfn>validating an object with JSON Schema</dfn> steps are still under discussion.
             Currently this specification reference to the validation process of JSONSchema. Please
             follow this <a href="https://json-schema.org/draft/2019-09/json-schema-validation.html">document</a> 
             when validating |init| with |exposedThingInitSchema|. Notice that the working group is evaluating an alternative formal approach.

--- a/index.html
+++ b/index.html
@@ -585,7 +585,13 @@
             <li>if |key| |value| is a <code>string</code> then if |value| is equal to one of the elements in |optional| remove |key| from |schema|</li>
           </ol>
         </li>
-        <li>Return the result of applying |schema| to |init|</li>
+        <li>Return the result of <a>validating</a> |init| with |schema|
+          <p class="ednote"><dfn>Validating</dfn> steps are still under discussion.
+            Currently this specification reference to the validation process of JSONSchema. Please
+            follow this <a href="https://json-schema.org/draft/2019-09/json-schema-validation.html">document</a> 
+            when validating |init| with |schema|. Notice that the working group is evaluating an alternative formal approach.
+          </p>
+        </li>
       </ol>
     </section>
   </section>

--- a/index.html
+++ b/index.html
@@ -369,7 +369,106 @@
       </div>
     </section>
   </section>
+  <section>
+    <h2>The <dfn>PartialTD</dfn> type</h2>
+    <pre class="idl">
+          typedef object PartialTD;
+    </pre>
+    The [[!WOT-ARCHITECTURE]] specification provides a formal definition of a <a>Partial TD</a> object. In this document, a
+    <a>PartialTD</a> is a dictionary used for the initialization of an <a>ExposedThing</a>. As such, it has the same 
+    structure of a <a>Thing Description</a> but it may omit some information. The example below shows a serialization of a 
+    <a>PartialTD</a> as a JSON object. It can be noticed that it is not a valid <a>Thing Description</a> because it misses the title, @context,
+    security information, and forms fields. Nevertheless, it could be used by a runtime as an hint to instantiate
+    the correct Thing Description; see <a>implement a PartialTD</a> algorithm for further details.
+    <pre class="example" title="A Partial TD">
+      {
+        "properties" : {
+          "temperature":{}
+        }
+      }
+    </pre>
+    <section>
+      <h3>Implement a PartialTD</h3>
+      To <dfn>implement a PartialTD</dfn> given |pTD:PartialTD| and obtain a valid |td:ThingDescription| as a result,
+      run the following steps:
+      <ol>
+        <li>Run <a>validate a PartialTD</a> on |pTD|. If that fails,
+        [= exception/throw =] {{SyntaxError}} and abort these steps.</li>
+        <li>Initialize and empty object called |td|</li>
+        <li>
+          For each property |key| in |pTD| copy |key| and value of |key| to |td| recursively.
+        </li>
+        <li>Search for missing required properties in |td| accordingly to 
+          <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#json-schema-for-validation">TD JSON Schema</a>. 
+          (TODO: possibly expand this step)</li>
+        <li>For each |missing| property run these sub-steps:
+        <ol>
+          <li>If |missing| is listed in the table below then use the algorithm described there to generate
+            a |value| for |missing|. 
+          </li>
+          <li>Otherwise [= exception/throw =] {{SyntaxError}} and abort these steps. 
+            (TODO: we could check for this condition in the validation)</li>
+          <li>Add |missing| to |td| with |value| as value</li>
+        </ol>
+        </li>
+        <li>Return |td|</li>
+        <table class="def">
+          <thead>
+            <tr>
+              <th>Property</th>
+              <th>Generate algorithm</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>href</td>
+              <td>TODO</td>
+            </tr>
+            <tr>
+              <td>title</td>
+              <td>TODO</td>
+            </tr>
+            <tr>
+              <td>@context</td>
+              <td>TODO</td>
+            </tr>
+            <tr>
+              <td>security</td>
+              <td>TODO</td>
+            </tr>
+            <tr>
+              <td>forms</td>
+              <td>TODO</td>
+            </tr>
+            <tr>
+              <td>instance</td>
+              <td>TODO</td>
+            </tr>
+          </tbody>
+        </table>
+      </ol>
+    </section>
+    <section>
+      <h3>Validating a PartialTD</h3>
+      To <dfn>validate a PartialTD</dfn> given |pTD:PartialTD|, run the following steps:
+      <ol>
+        <li>
+          Parse <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#json-schema-for-validation">TD JSON Schema</a>
+          and load it in object called |schema|
+        </li>
+        <li>
+        For each property |key| in |schema|,
+        <ol>
+          <li>If |key| equals <code>required</code> then remove |key| from |schema|</li>
+        </ol>
+        </li>
+        <li>Return the result of applying |schema| to |pTD|</li>
+      </ol>
 
+      TODO: is there any property that we should still require? for example flow property is mandatory for oAuth Security scheme. 
+      See also <a>implement a PartialTD</a>
+    </section>
+  </section>
   <section data-dfn-for="WOT">
   <h2>The <dfn>WOT</dfn> namespace</dfn></h2>
   <p>
@@ -424,11 +523,11 @@
   <section> <h3>The <dfn>produce()</dfn> method</h3>
     <pre class="idl">
       partial namespace WOT {
-        Promise&lt;ExposedThing&gt; produce(ThingDescription td);
+        Promise&lt;ExposedThing&gt; produce(PartialTD pTD);
       };
     </pre>
     <div>
-      Belongs to the <a>WoT Producer</a> conformance class. Expects a |td:ThingDescription| argument and returns a {{Promise}} that resolves with an {{ExposedThing}} object that extends {{ConsumedThing}} with a server interface, i.e. the ability to define request handlers. The method MUST run the following steps:
+      Belongs to the <a>WoT Producer</a> conformance class. Expects a |pTD:ThingDescription| argument and returns a {{Promise}} that resolves with an {{ExposedThing}} object that extends {{ConsumedThing}} with a server interface, i.e. the ability to define request handlers. The method MUST run the following steps:
       <ol>
         <li>
           Return a {{Promise}} |promise:Promise| and execute the next steps <a>in parallel</a>.
@@ -437,7 +536,7 @@
           If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
         </li>
         <li>
-          Let |thing:ExposedThing| be a new {{ExposedThing}} object constructed with |td|.
+          Let |thing:ExposedThing| be a new {{ExposedThing}} object constructed with |pTD|.
         </li>
         <li>
           Resolve |promise| with |thing|.
@@ -2112,12 +2211,13 @@
         Before invoking <a href="#dom-exposedthing-expose">expose()</a>, the {{ExposedThing}} object does not serve any requests. This allows first constructing {{ExposedThing}} and then initialize its <a>Properties</a> and service handlers before starting serving requests.
       </p>
       <div>
-        To construct an {{ExposedThing}} with the {{ThingDescription}}
-        |td:ThingDescription|, run the following steps:
+        To construct an {{ExposedThing}} with the {{PartialTD}}
+        |pTD:PartialTD|, run the following steps:
         <ol>
           <li>
             If invoking this method is not allowed for the current scripting context for security reasons, [= exception/throw =] a {{SecurityError}} and abort these steps.
           </li>
+          <li>Run the <a>implement a PartialTD</a> steps on |pTD|. if that fails re-[= exception/throw =] the error and abort these steps. Otherwise store the obtained |td:ThingDescription| </li>
           <li>
             Run the <a>expand a TD</a> steps on |td|. If that fails, re-[= exception/throw =] the error and abort these steps.
           </li>
@@ -3702,7 +3802,7 @@
 
   <section> <h2>Terminology and conventions</h2>
     <p>
-      The generic WoT terminology is defined in [[!WOT-ARCHITECTURE]]: <dfn data-lt="Things">Thing</dfn>, <dfn data-lt="Thing Descriptions">Thing Description</dfn> (in short <dfn>TD</dfn>), <dfn>Web of Things</dfn> (in short <b><i>WoT</i></b>),  <dfn>WoT Interface</dfn>, <dfn>Protocol Bindings</dfn>, <dfn>WoT Runtime</dfn>, <dfn data-lt="consume|consume a TD|consuming a TD">Consuming a Thing Description</dfn>, <dfn>Thing Directory</dfn>, <dfn data-lt="Properties">Property</dfn>, <dfn data-lt="Actions">Action</dfn>, <dfn data-lt="Events|WoT-Event">Event</dfn>,
+      The generic WoT terminology is defined in [[!WOT-ARCHITECTURE]]: <dfn data-lt="Things">Thing</dfn>, <dfn data-lt="Thing Descriptions">Thing Description</dfn> (in short <dfn>TD</dfn>), <dfn>Partial TD</dfn>, <dfn>Web of Things</dfn> (in short <b><i>WoT</i></b>),  <dfn>WoT Interface</dfn>, <dfn>Protocol Bindings</dfn>, <dfn>WoT Runtime</dfn>, <dfn data-lt="consume|consume a TD|consuming a TD">Consuming a Thing Description</dfn>, <dfn>Thing Directory</dfn>, <dfn data-lt="Properties">Property</dfn>, <dfn data-lt="Actions">Action</dfn>, <dfn data-lt="Events|WoT-Event">Event</dfn>,
       <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#dataschema">
         <dfn>DataSchema</dfn></a>, <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#form"><dfn>Form</dfn></a> etc.
     </p>

--- a/index.html
+++ b/index.html
@@ -463,8 +463,8 @@
         <li>
           For each property |key| in |init| copy |key| and value of |key| to |td| recursively.
         </li>
-        <li>For each |scheme:SecurityScheme| defined in <code>securityDefinitions</code> check if it is supported by the <a>Protocol Bindings</a>. 
-        if not remove scheme </li>
+        <li>For each |scheme:SecurityScheme| defined in <code>securityDefinitions</code> check if it is supported by at least one <a>Protocol Binding</a>. 
+        If not remove scheme </li>
         <li>if the value of <code>security</code> is defined but it is not contained in <code>securityDefinitions</code> remove 
         <code>security</code></li>
         <li>For each |affordance| run the following sub-steps:

--- a/index.html
+++ b/index.html
@@ -92,6 +92,65 @@
         },
       };
     </script>
+    <script>
+      document.addEventListener("DOMContentLoaded", () => {
+        // Add example button selection logic
+        for (const button of document.querySelectorAll(".ds-selector-tabs .selectors button")) {
+          button.onclick = () => {
+            const ex = button.closest(".ds-selector-tabs");
+            ex.querySelector("button.selected").classList.remove("selected");
+            ex.querySelector(".selected").classList.remove("selected");
+            button.classList.add('selected');
+            ex.querySelector("." + button.dataset.selects).classList.add("selected");
+          }
+        }
+      });
+    </script>
+    <style>
+    /* example tab selection */
+  .ds-selector-tabs {
+    padding-bottom: 2em;
+  }
+  .ds-selector-tabs .selectors {
+    padding: 0;
+    border-bottom: 1px solid #ccc;
+    height: 28px;
+  }
+  .ds-selector-tabs .selectors button {
+    display: inline-block;
+    min-width: 54px;
+    text-align: center;
+    font-size: 11px;
+    font-weight: bold;
+    height: 27px;
+    padding: 0 8px;
+    line-height: 27px;
+    transition: all,0.218s;
+    border-top-right-radius: 2px;
+    border-top-left-radius: 2px;
+    color: #666;
+    border: 1px solid transparent;
+  }
+  .ds-selector-tabs .selectors button:first-child {
+    margin-left: 2px;
+  }
+  .ds-selector-tabs .selectors button.selected {
+    color: #202020 !important;
+    border: 1px solid #ccc;
+    border-bottom: 1px solid #fff !important;
+  }
+  .ds-selector-tabs .selectors button:hover {
+    background-color: transparent;
+    color: #202020;
+    cursor: pointer;
+  }
+  .ds-selector-tabs pre:not(.preserve), .ds-selector-tabs table:not(.preserve) {
+    display: none;
+  }
+  .ds-selector-tabs pre.selected, .ds-selector-tabs table.selected {
+    display: block;
+  }
+    </style>
   </head>
   <body>
 
@@ -3357,13 +3416,43 @@
       misses the title, @context,
       security information, and forms fields. Nevertheless, it could be used by a runtime as an hint to instantiate
       the correct Thing Description; see <a>expand an ExposedThingInit</a> algorithm for further details.</p>
-      <pre class="example" title="An instance of the ExposedThingInit type">
-              {
-                "properties" : {
-                  "temperature":{}
-                }
+      <aside class="example ds-selector-tabs" title="TODO">
+        <div class="selectors">
+          <button class="selected" data-selects="init">ExposedThingInit</button>
+          <button data-selects="td">ThingDescription</button>
+        </div>
+        
+        <pre class="selected init" data-transform="updateExample" title="An instance of the ExposedThingInit type">
+          {
+            "properties" : {
+              "temperature":{}
+            }
+          }
+        </pre>
+        <pre class="td" data-transform="updateExample" >
+          {
+            "@context": [
+              "https://www.w3.org/2019/wot/td/v1"
+            ],
+            "title": "Thing-123",
+            "securityDefinitions": {
+              "no_sec": {
+                "scheme": "nosec"
               }
-      </pre>
+            },
+            "security": "no_sec",
+            "properties": {
+              "temperature": {
+                "forms": [{
+                  "href": "http://localhost:8080/properties/temperature",
+                  "contentType": "application/json"
+                }]
+              }
+            }
+          }
+        </pre>
+      </aside>
+     
     </section> <!-- ExposedThing Examples -->
   </section> <!-- ExposedThing -->
 

--- a/index.html
+++ b/index.html
@@ -574,22 +574,22 @@
         <li>
           Parse <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#json-schema-for-validation">TD JSON
             Schema</a>
-          and load it in object called |schema|
+          and load it in object called |exposedThingInitSchema:object|
         </li>
         <li>let |optional:Array| be a list containing the following strings: <code>title</code>, <code>@context</code>, 
         <code>instance</code>, <code>forms</code>, <code>security</code>, and <code>href</code>. </li>
         <li>
-          For each property and sub-property |key| in |schema| equals to <code>required</code> execute the following steps:
+          For each property and sub-property |key| in |exposedThingInitSchema| equals to <code>required</code> execute the following steps:
           <ol>
             <li>if |key| |value| is an <code>Array</code> then remove all its elements equal to the elements in |optional|</li>
-            <li>if |key| |value| is a <code>string</code> then if |value| is equal to one of the elements in |optional| remove |key| from |schema|</li>
+            <li>if |key| |value| is a <code>string</code> then if |value| is equal to one of the elements in |optional| remove |key| from |exposedThingInitSchema|</li>
           </ol>
         </li>
-        <li>Return the result of <a>validating</a> |init| with |schema|
+        <li>Return the result of <a>validating</a> |init| with |exposedThingInitSchema|
           <p class="ednote"><dfn>Validating</dfn> steps are still under discussion.
             Currently this specification reference to the validation process of JSONSchema. Please
             follow this <a href="https://json-schema.org/draft/2019-09/json-schema-validation.html">document</a> 
-            when validating |init| with |schema|. Notice that the working group is evaluating an alternative formal approach.
+            when validating |init| with |exposedThingInitSchema|. Notice that the working group is evaluating an alternative formal approach.
           </p>
         </li>
       </ol>

--- a/index.html
+++ b/index.html
@@ -452,8 +452,8 @@
       </ol>
     </div>
     <section>
-      <h3>Use an ExposedThingInit</h3>
-      To <dfn>use an ExposedThingInit</dfn> given |init:ExposedThingInit| and obtain a valid |td:ThingDescription| as
+      <h3>Expand an ExposedThingInit</h3>
+      To <dfn>expand an ExposedThingInit</dfn> given |init:ExposedThingInit| and obtain a valid |td:ThingDescription| as
       a result,
       run the following steps:
       <ol>
@@ -527,7 +527,7 @@
     
       TODO: is there any property that we should still require? for example flow property is mandatory for oAuth Security
       scheme.
-      See also <a>use an ExposedThingInit</a>
+      See also <a>expand an ExposedThingInit</a>
     </section>
   </section>
 
@@ -2203,7 +2203,7 @@
           <li>
             If invoking this method is not allowed for the current scripting context for security reasons, [= exception/throw =] a {{SecurityError}} and abort these steps.
           </li>
-          <li>Run the <a>use an ExposedThingInit</a> steps on |init|. if that fails re-[= exception/throw =] the error and abort these steps. Otherwise store the obtained |td:ThingDescription| </li>
+          <li>Run the <a>expand an ExposedThingInit</a> steps on |init|. if that fails re-[= exception/throw =] the error and abort these steps. Otherwise store the obtained |td:ThingDescription| </li>
           <li>
             Run the <a>expand a TD</a> steps on |td|. If that fails, re-[= exception/throw =] the error and abort these steps.
           </li>
@@ -3356,7 +3356,7 @@
       <a>ExposedThingInit</a> as a JSON object. It can be noticed that it is not a valid <a>Thing Description</a> because it
       misses the title, @context,
       security information, and forms fields. Nevertheless, it could be used by a runtime as an hint to instantiate
-      the correct Thing Description; see <a>use an ExposedThingInit</a> algorithm for further details.</p>
+      the correct Thing Description; see <a>expand an ExposedThingInit</a> algorithm for further details.</p>
       <pre class="example" title="An instance of the ExposedThingInit type">
               {
                 "properties" : {

--- a/index.html
+++ b/index.html
@@ -370,17 +370,17 @@
     </section>
   </section>
   <section>
-    <h2>The <dfn>PartialTD</dfn> type</h2>
+    <h2>The <dfn>ExposedThingInit</dfn> type</h2>
     <pre class="idl">
-          typedef object PartialTD;
+          typedef object ExposedThingInit;
     </pre>
-    The [[!WOT-ARCHITECTURE]] specification provides a formal definition of a <a>Partial TD</a> object. In this document, a
-    <a>PartialTD</a> is a dictionary used for the initialization of an <a>ExposedThing</a>. As such, it has the same 
+    An <a>ExposedThingInit</a> is a dictionary used for the initialization of an <a>ExposedThing</a>. It represents an instance
+    of a <a>Partial TD</a> as described in the [[!WOT-ARCHITECTURE]]. As such, it has the same 
     structure of a <a>Thing Description</a> but it may omit some information. The example below shows a serialization of a 
-    <a>PartialTD</a> as a JSON object. It can be noticed that it is not a valid <a>Thing Description</a> because it misses the title, @context,
+    <a>ExposedThingInit</a> as a JSON object. It can be noticed that it is not a valid <a>Thing Description</a> because it misses the title, @context,
     security information, and forms fields. Nevertheless, it could be used by a runtime as an hint to instantiate
-    the correct Thing Description; see <a>implement a PartialTD</a> algorithm for further details.
-    <pre class="example" title="A Partial TD">
+    the correct Thing Description; see <a>implement an ExposedThingInit</a> algorithm for further details.
+    <pre class="example" title="An instance of the ExposedThingInit type">
       {
         "properties" : {
           "temperature":{}
@@ -388,15 +388,15 @@
       }
     </pre>
     <section>
-      <h3>Implement a PartialTD</h3>
-      To <dfn>implement a PartialTD</dfn> given |pTD:PartialTD| and obtain a valid |td:ThingDescription| as a result,
+      <h3>Implement an ExposedThingInit</h3>
+      To <dfn>implement an ExposedThingInit</dfn> given |init:ExposedThingInit| and obtain a valid |td:ThingDescription| as a result,
       run the following steps:
       <ol>
-        <li>Run <a>validate a PartialTD</a> on |pTD|. If that fails,
+        <li>Run <a>validate an ExposedThingInit</a> on |init|. If that fails,
         [= exception/throw =] {{SyntaxError}} and abort these steps.</li>
         <li>Initialize and empty object called |td|</li>
         <li>
-          For each property |key| in |pTD| copy |key| and value of |key| to |td| recursively.
+          For each property |key| in |init| copy |key| and value of |key| to |td| recursively.
         </li>
         <li>Search for missing required properties in |td| accordingly to 
           <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#json-schema-for-validation">TD JSON Schema</a>. 
@@ -449,8 +449,8 @@
       </ol>
     </section>
     <section>
-      <h3>Validating a PartialTD</h3>
-      To <dfn>validate a PartialTD</dfn> given |pTD:PartialTD|, run the following steps:
+      <h3>Validating an ExposedThingInit</h3>
+      To <dfn>validate an ExposedThingInit</dfn> given |init:ExposedThingInit|, run the following steps:
       <ol>
         <li>
           Parse <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#json-schema-for-validation">TD JSON Schema</a>
@@ -462,11 +462,11 @@
           <li>If |key| equals <code>required</code> then remove |key| from |schema|</li>
         </ol>
         </li>
-        <li>Return the result of applying |schema| to |pTD|</li>
+        <li>Return the result of applying |schema| to |init|</li>
       </ol>
 
       TODO: is there any property that we should still require? for example flow property is mandatory for oAuth Security scheme. 
-      See also <a>implement a PartialTD</a>
+      See also <a>implement an ExposedThingInit</a>
     </section>
   </section>
   <section data-dfn-for="WOT">
@@ -523,11 +523,11 @@
   <section> <h3>The <dfn>produce()</dfn> method</h3>
     <pre class="idl">
       partial namespace WOT {
-        Promise&lt;ExposedThing&gt; produce(PartialTD pTD);
+        Promise&lt;ExposedThing&gt; produce(ExposedThingInit init);
       };
     </pre>
     <div>
-      Belongs to the <a>WoT Producer</a> conformance class. Expects a |pTD:ThingDescription| argument and returns a {{Promise}} that resolves with an {{ExposedThing}} object that extends {{ConsumedThing}} with a server interface, i.e. the ability to define request handlers. The method MUST run the following steps:
+      Belongs to the <a>WoT Producer</a> conformance class. Expects a |init:ExposedThingInit| argument and returns a {{Promise}} that resolves with an {{ExposedThing}} object that extends {{ConsumedThing}} with a server interface, i.e. the ability to define request handlers. The method MUST run the following steps:
       <ol>
         <li>
           Return a {{Promise}} |promise:Promise| and execute the next steps <a>in parallel</a>.
@@ -536,7 +536,7 @@
           If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
         </li>
         <li>
-          Let |thing:ExposedThing| be a new {{ExposedThing}} object constructed with |pTD|.
+          Let |thing:ExposedThing| be a new {{ExposedThing}} object constructed with |init|.
         </li>
         <li>
           Resolve |promise| with |thing|.
@@ -2211,13 +2211,13 @@
         Before invoking <a href="#dom-exposedthing-expose">expose()</a>, the {{ExposedThing}} object does not serve any requests. This allows first constructing {{ExposedThing}} and then initialize its <a>Properties</a> and service handlers before starting serving requests.
       </p>
       <div>
-        To construct an {{ExposedThing}} with the {{PartialTD}}
-        |pTD:PartialTD|, run the following steps:
+        To construct an {{ExposedThing}} with the {{ExposedThingInit}}
+        |init:ExposedThingInit|, run the following steps:
         <ol>
           <li>
             If invoking this method is not allowed for the current scripting context for security reasons, [= exception/throw =] a {{SecurityError}} and abort these steps.
           </li>
-          <li>Run the <a>implement a PartialTD</a> steps on |pTD|. if that fails re-[= exception/throw =] the error and abort these steps. Otherwise store the obtained |td:ThingDescription| </li>
+          <li>Run the <a>implement an ExposedThingInit</a> steps on |init|. if that fails re-[= exception/throw =] the error and abort these steps. Otherwise store the obtained |td:ThingDescription| </li>
           <li>
             Run the <a>expand a TD</a> steps on |td|. If that fails, re-[= exception/throw =] the error and abort these steps.
           </li>

--- a/index.html
+++ b/index.html
@@ -369,106 +369,6 @@
       </div>
     </section>
   </section>
-  <section>
-    <h2>The <dfn>ExposedThingInit</dfn> type</h2>
-    <pre class="idl">
-          typedef object ExposedThingInit;
-    </pre>
-    An <a>ExposedThingInit</a> is a dictionary used for the initialization of an <a>ExposedThing</a>. It represents a <a>Partial TD</a> 
-    as described in the [[!WOT-ARCHITECTURE]]. As such, it has the same 
-    structure of a <a>Thing Description</a> but it may omit some information. The example below shows a serialization of a 
-    <a>ExposedThingInit</a> as a JSON object. It can be noticed that it is not a valid <a>Thing Description</a> because it misses the title, @context,
-    security information, and forms fields. Nevertheless, it could be used by a runtime as an hint to instantiate
-    the correct Thing Description; see <a>implement an ExposedThingInit</a> algorithm for further details.
-    <pre class="example" title="An instance of the ExposedThingInit type">
-      {
-        "properties" : {
-          "temperature":{}
-        }
-      }
-    </pre>
-    <section>
-      <h3>Implement an ExposedThingInit</h3>
-      To <dfn>implement an ExposedThingInit</dfn> given |init:ExposedThingInit| and obtain a valid |td:ThingDescription| as a result,
-      run the following steps:
-      <ol>
-        <li>Run <a>validate an ExposedThingInit</a> on |init|. If that fails,
-        [= exception/throw =] {{SyntaxError}} and abort these steps.</li>
-        <li>Initialize and empty object called |td|</li>
-        <li>
-          For each property |key| in |init| copy |key| and value of |key| to |td| recursively.
-        </li>
-        <li>Search for missing required properties in |td| accordingly to 
-          <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#json-schema-for-validation">TD JSON Schema</a>. 
-          (TODO: possibly expand this step)</li>
-        <li>For each |missing| property run these sub-steps:
-        <ol>
-          <li>If |missing| is listed in the table below then use the algorithm described there to generate
-            a |value| for |missing|. 
-          </li>
-          <li>Otherwise [= exception/throw =] {{SyntaxError}} and abort these steps. 
-            (TODO: we could check for this condition in the validation)</li>
-          <li>Add |missing| to |td| with |value| as value</li>
-        </ol>
-        </li>
-        <li>Return |td|</li>
-        <table class="def">
-          <thead>
-            <tr>
-              <th>Property</th>
-              <th>Generate algorithm</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>href</td>
-              <td>TODO</td>
-            </tr>
-            <tr>
-              <td>title</td>
-              <td>TODO</td>
-            </tr>
-            <tr>
-              <td>@context</td>
-              <td>TODO</td>
-            </tr>
-            <tr>
-              <td>security</td>
-              <td>TODO</td>
-            </tr>
-            <tr>
-              <td>forms</td>
-              <td>TODO</td>
-            </tr>
-            <tr>
-              <td>instance</td>
-              <td>TODO</td>
-            </tr>
-          </tbody>
-        </table>
-      </ol>
-    </section>
-    <section>
-      <h3>Validating an ExposedThingInit</h3>
-      To <dfn>validate an ExposedThingInit</dfn> given |init:ExposedThingInit|, run the following steps:
-      <ol>
-        <li>
-          Parse <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#json-schema-for-validation">TD JSON Schema</a>
-          and load it in object called |schema|
-        </li>
-        <li>
-        For each property |key| in |schema|,
-        <ol>
-          <li>If |key| equals <code>required</code> then remove |key| from |schema|</li>
-        </ol>
-        </li>
-        <li>Return the result of applying |schema| to |init|</li>
-      </ol>
-
-      TODO: is there any property that we should still require? for example flow property is mandatory for oAuth Security scheme. 
-      See also <a>implement an ExposedThingInit</a>
-    </section>
-  </section>
   <section data-dfn-for="WOT">
   <h2>The <dfn>WOT</dfn> namespace</dfn></h2>
   <p>
@@ -522,12 +422,20 @@
 
   <section> <h3>The <dfn>produce()</dfn> method</h3>
     <pre class="idl">
+      typedef object ExposedThingInit;
+
       partial namespace WOT {
         Promise&lt;ExposedThing&gt; produce(ExposedThingInit init);
       };
     </pre>
     <div>
-      Belongs to the <a>WoT Producer</a> conformance class. Expects a |init:ExposedThingInit| argument and returns a {{Promise}} that resolves with an {{ExposedThing}} object that extends {{ConsumedThing}} with a server interface, i.e. the ability to define request handlers. The method MUST run the following steps:
+      Belongs to the <a>WoT Producer</a> conformance class. Expects a |init:ExposedThingInit| argument and returns a {{Promise}} 
+      that resolves with an {{ExposedThing}} object that extends {{ConsumedThing}} with a server interface, 
+      i.e. the ability to define request handlers. The |init:ExposedThingInit| object is an instance of the <a>ExposedThingInit</a> type.
+      Specifically, an <a>ExposedThingInit</a> value is a dictionary used for the initialization of an <a>ExposedThing</a> and
+      it represents a <a>Partial TD</a> as described in the [[!WOT-ARCHITECTURE]]. As such, it has the same
+      structure of a <a>Thing Description</a> but it may omit some information. 
+      The method MUST run the following steps:
       <ol>
         <li>
           Return a {{Promise}} |promise:Promise| and execute the next steps <a>in parallel</a>.
@@ -543,6 +451,92 @@
         </li>
       </ol>
     </div>
+    <section>
+      <h3>Use an ExposedThingInit</h3>
+      To <dfn>use an ExposedThingInit</dfn> given |init:ExposedThingInit| and obtain a valid |td:ThingDescription| as
+      a result,
+      run the following steps:
+      <ol>
+        <li>Run <a>validate an ExposedThingInit</a> on |init|. If that fails,
+          [= exception/throw =] {{SyntaxError}} and abort these steps.</li>
+        <li>Initialize and empty object called |td|</li>
+        <li>
+          For each property |key| in |init| copy |key| and value of |key| to |td| recursively.
+        </li>
+        <li>Search for missing required properties in |td| accordingly to
+          <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#json-schema-for-validation">TD JSON
+            Schema</a>.
+          (TODO: possibly expand this step)
+        </li>
+        <li>For each |missing| property run these sub-steps:
+          <ol>
+            <li>If |missing| is listed in the table below then use the algorithm described there to generate
+              a |value| for |missing|.
+            </li>
+            <li>Otherwise [= exception/throw =] {{SyntaxError}} and abort these steps.
+              (TODO: we could check for this condition in the validation)</li>
+            <li>Add |missing| to |td| with |value| as value</li>
+          </ol>
+        </li>
+        <li>Return |td|</li>
+        <table class="def">
+          <thead>
+            <tr>
+              <th>Property</th>
+              <th>Generate algorithm</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>href</td>
+              <td>TODO</td>
+            </tr>
+            <tr>
+              <td>title</td>
+              <td>TODO</td>
+            </tr>
+            <tr>
+              <td>@context</td>
+              <td>TODO</td>
+            </tr>
+            <tr>
+              <td>security</td>
+              <td>TODO</td>
+            </tr>
+            <tr>
+              <td>forms</td>
+              <td>TODO</td>
+            </tr>
+            <tr>
+              <td>instance</td>
+              <td>TODO</td>
+            </tr>
+          </tbody>
+        </table>
+      </ol>
+    </section>
+    <section>
+      <h3>Validating an ExposedThingInit</h3>
+      To <dfn>validate an ExposedThingInit</dfn> given |init:ExposedThingInit|, run the following steps:
+      <ol>
+        <li>
+          Parse <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#json-schema-for-validation">TD JSON
+            Schema</a>
+          and load it in object called |schema|
+        </li>
+        <li>
+          For each property |key| in |schema|,
+          <ol>
+            <li>If |key| equals <code>required</code> then remove |key| from |schema|</li>
+          </ol>
+        </li>
+        <li>Return the result of applying |schema| to |init|</li>
+      </ol>
+    
+      TODO: is there any property that we should still require? for example flow property is mandatory for oAuth Security
+      scheme.
+      See also <a>use an ExposedThingInit</a>
+    </section>
   </section>
 
   <section> <h3>The <dfn>discover()</dfn> method</h3>
@@ -2217,7 +2211,7 @@
           <li>
             If invoking this method is not allowed for the current scripting context for security reasons, [= exception/throw =] a {{SecurityError}} and abort these steps.
           </li>
-          <li>Run the <a>implement an ExposedThingInit</a> steps on |init|. if that fails re-[= exception/throw =] the error and abort these steps. Otherwise store the obtained |td:ThingDescription| </li>
+          <li>Run the <a>use an ExposedThingInit</a> steps on |init|. if that fails re-[= exception/throw =] the error and abort these steps. Otherwise store the obtained |td:ThingDescription| </li>
           <li>
             Run the <a>expand a TD</a> steps on |td|. If that fails, re-[= exception/throw =] the error and abort these steps.
           </li>
@@ -3365,6 +3359,18 @@
         } catch (err) {
            console.log("Error creating ExposedThing: " + err);
         }
+      </pre>
+      <p>The example below shows a serialization of a
+      <a>ExposedThingInit</a> as a JSON object. It can be noticed that it is not a valid <a>Thing Description</a> because it
+      misses the title, @context,
+      security information, and forms fields. Nevertheless, it could be used by a runtime as an hint to instantiate
+      the correct Thing Description; see <a>use an ExposedThingInit</a> algorithm for further details.</p>
+      <pre class="example" title="An instance of the ExposedThingInit type">
+              {
+                "properties" : {
+                  "temperature":{}
+                }
+              }
       </pre>
     </section> <!-- ExposedThing Examples -->
   </section> <!-- ExposedThing -->

--- a/index.html
+++ b/index.html
@@ -3417,12 +3417,16 @@
            console.log("Error creating ExposedThing: " + err);
         }
       </pre>
-      <p>The example below shows a serialization of a
-      <a>ExposedThingInit</a> as a JSON object. It can be noticed that it is not a valid <a>Thing Description</a> because it
-      misses the title, @context,
-      security information, and forms fields. Nevertheless, it could be used by a runtime as an hint to instantiate
-      the correct Thing Description; see <a>expand an ExposedThingInit</a> algorithm for further details.</p>
-      <aside class="example ds-selector-tabs" title="TODO">
+      <p>
+        The following will cover a set of examples for the generation of a <a>Thing Description</a> from 
+        an <a>ExposedThingInit</a> using <a>expand an ExposedThingInit</a> steps. As hypothesis the runtime 
+        supports HTTP and COAP protocol bindings and it is hosted at 192.168.0.1. 
+      </p>
+      <p>
+        The next example shows how to exploit a <a>ExposedThingInit</a> to create a simple <a>Thing Description</a>
+        with one <a>Property</a> with the default values. 
+      </p>
+      <aside class="example ds-selector-tabs" title="Create a Thing Description with one Property afforndace">
         <div class="selectors">
           <button class="selected" data-selects="init">ExposedThingInit</button>
           <button data-selects="td">ThingDescription</button>
@@ -3450,15 +3454,21 @@
             "properties": {
               "temperature": {
                 "forms": [{
-                  "href": "http://localhost:8080/properties/temperature",
+                  "href": "http://192.168.0.1:8080/properties/temperature",
                   "contentType": "application/json"
+                },
+                {
+                "href": "coap://192.168.0.1:9090/properties/temperature",
+                "contentType": "application/json"
                 }]
               }
             }
           }
         </pre>
       </aside>
-     
+     <p class="ednote">
+       TODO: add more examples where the <a>ExposedThingInit</a> contains suggested values that are replaced by the algorithm.
+     </p>
     </section> <!-- ExposedThing Examples -->
   </section> <!-- ExposedThing -->
 

--- a/index.html
+++ b/index.html
@@ -463,6 +463,24 @@
         <li>
           For each property |key| in |init| copy |key| and value of |key| to |td| recursively.
         </li>
+        <li>For each |scheme:SecurityScheme| defined in <code>securityDefinitions</code> check if it is supported by the <a>Protocol Bindings</a>. 
+        if not remove scheme </li>
+        <li>if the value of <code>security</code> is defined but it is not contained in <code>securityDefinitions</code> remove 
+        <code>security</code></li>
+        <li>For each |affordance| run the following sub-steps:
+          <ol>
+            <li>For each |form:Form| defined in |affordance| execute:
+              <ol>
+                <li>if |form|'s |contentType:string| is not recognized by the runtime as valid remove |contentType:string| from |form|
+                </li>
+                <li>if |form|'s |href:URL| has an unknown schema remove |href| from |form|.</li>
+                <li>if |form|'s |href:URL| is absolute and its <code>authority</code> it is not recognized by the runtime as a valid
+                  remove |href| from |form|. </li>
+                <li>if |form|'s |href:URL| is already in use by other <a>ExposedThings</a> remove |href| from |form|.</li>
+              </ol>
+            </li>
+          </ol>
+        </li>
         <li>Search for missing required properties in |td| accordingly to
           <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#json-schema-for-validation">TD JSON
             Schema</a>.
@@ -470,49 +488,23 @@
         </li>
         <li>For each |missing| property run these sub-steps:
           <ol>
-            <li>If |missing| is listed in the table below then use the algorithm described there to generate
-              a |value| for |missing|.
-            </li>
+            <li>If |missing| is <code>title</code> generate a runtime unique name and assign to <code>title</code>.</li> 
+            <li>If |missing| is <code>@context</code> assign the latest supported Thing Description context URI.</li>
+            <li>If |missing| is <code>instance</code> assign the string <code>1.0.0</code>.</li>
+            <li>If |missing| is <code>forms</code> generate a list of <a>Forms</a> using the available <a>Protocol Bindings</a> and content types
+              encoders. Then assign the obtained list to <code>forms</code>. (TODO: expand?)</li>
+            <li>If |missing| is <code>security</code> assign the label of the first supported <a>SecurityScheme</a> in <code>securityDefinitions</code> field. 
+            If no <a>SecurityScheme</a> is found generate a <a>NoSecurityScheme</a> called <code>nosec</code> and assing the string <code>nosec</code>
+          to <code>security</code>. (TODO: ask for guidance to Security task force)  </li>
+            <li>If |missing| is <code>href</code> define |formStub| as the partial <a>Form</a> that does not have <code>href</code>. Generate a valid |url:URL| using the first <a>Protocol Binding</a> 
+              that satisfy the requirements of |formStub|. Assign |url| to <code>href</code>. If not <a>Protocol Binding</a> can be found remove |formStub| from |td|. </li>
             <li>Otherwise [= exception/throw =] {{SyntaxError}} and abort these steps.
               (TODO: we could check for this condition in the validation)</li>
             <li>Add |missing| to |td| with |value| as value</li>
           </ol>
         </li>
+        <li>Run <a>validate a TD</a> on |td|. If that fails re-[= exception/throw =] the error and abort these steps</li>
         <li>Return |td|</li>
-        <table class="def">
-          <thead>
-            <tr>
-              <th>Property</th>
-              <th>Generate algorithm</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>href</td>
-              <td>TODO</td>
-            </tr>
-            <tr>
-              <td>title</td>
-              <td>TODO</td>
-            </tr>
-            <tr>
-              <td>@context</td>
-              <td>TODO</td>
-            </tr>
-            <tr>
-              <td>security</td>
-              <td>TODO</td>
-            </tr>
-            <tr>
-              <td>forms</td>
-              <td>TODO</td>
-            </tr>
-            <tr>
-              <td>instance</td>
-              <td>TODO</td>
-            </tr>
-          </tbody>
-        </table>
       </ol>
     </section>
     <section>
@@ -3810,7 +3802,8 @@
     <p>
       The generic WoT terminology is defined in [[!WOT-ARCHITECTURE]]: <dfn data-lt="Things">Thing</dfn>, <dfn data-lt="Thing Descriptions">Thing Description</dfn> (in short <dfn>TD</dfn>), <dfn>Partial TD</dfn>, <dfn>Web of Things</dfn> (in short <b><i>WoT</i></b>),  <dfn>WoT Interface</dfn>, <dfn>Protocol Bindings</dfn>, <dfn>WoT Runtime</dfn>, <dfn data-lt="consume|consume a TD|consuming a TD">Consuming a Thing Description</dfn>, <dfn>Thing Directory</dfn>, <dfn data-lt="Properties">Property</dfn>, <dfn data-lt="Actions">Action</dfn>, <dfn data-lt="Events|WoT-Event">Event</dfn>,
       <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#dataschema">
-        <dfn>DataSchema</dfn></a>, <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#form"><dfn>Form</dfn></a> etc.
+        <dfn>DataSchema</dfn></a>, <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#form"><dfn data-lt="Forms">Form</dfn></a>,
+        <a href="https://w3c.github.io/wot-thing-description/#securityscheme"><dfn>SecurityScheme</dfn></a>, <a href="https://w3c.github.io/wot-thing-description/#nosecurityscheme"><dfn>NoSecurityScheme</dfn></a> etc.
     </p>
     <p>
       <dfn data-plurals="WoT Interactions">WoT Interaction</dfn> is a synonym for <a href="https://www.w3.org/TR/2020/WD-wot-architcture11-20201124/#dfn-interaction-affordance"><dfn>Interaction Affordance</dfn></a>.

--- a/index.html
+++ b/index.html
@@ -498,8 +498,6 @@
           to <code>security</code>. (TODO: ask for guidance to Security task force)  </li>
             <li>If |missing| is <code>href</code> define |formStub| as the partial <a>Form</a> that does not have <code>href</code>. Generate a valid |url:URL| using the first <a>Protocol Binding</a> 
               that satisfy the requirements of |formStub|. Assign |url| to <code>href</code>. If not <a>Protocol Binding</a> can be found remove |formStub| from |td|. </li>
-            <li>Otherwise [= exception/throw =] {{SyntaxError}} and abort these steps.
-              (TODO: we could check for this condition in the validation)</li>
             <li>Add |missing| to |td| with |value| as value</li>
           </ol>
         </li>
@@ -516,18 +514,17 @@
             Schema</a>
           and load it in object called |schema|
         </li>
+        <li>let |optional:Array| be a list containing the following strings: <code>title</code>, <code>@context</code>, 
+        <code>instance</code>, <code>forms</code>, <code>security</code>, and <code>href</code>. </li>
         <li>
-          For each property |key| in |schema|,
+          For each property and sub-property |key| in |schema| equals to <code>required</code> execute the following steps:
           <ol>
-            <li>If |key| equals <code>required</code> then remove |key| from |schema|</li>
+            <li>if |key| |value| is an <code>Array</code> then remove all its elements equal to the elements in |optional|</li>
+            <li>if |key| |value| is a <code>string</code> then if |value| is equal to one of the elements in |optional| remove |key| from |schema|</li>
           </ol>
         </li>
         <li>Return the result of applying |schema| to |init|</li>
       </ol>
-    
-      TODO: is there any property that we should still require? for example flow property is mandatory for oAuth Security
-      scheme.
-      See also <a>expand an ExposedThingInit</a>
     </section>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -374,8 +374,8 @@
     <pre class="idl">
           typedef object ExposedThingInit;
     </pre>
-    An <a>ExposedThingInit</a> is a dictionary used for the initialization of an <a>ExposedThing</a>. It represents an instance
-    of a <a>Partial TD</a> as described in the [[!WOT-ARCHITECTURE]]. As such, it has the same 
+    An <a>ExposedThingInit</a> is a dictionary used for the initialization of an <a>ExposedThing</a>. It represents a <a>Partial TD</a> 
+    as described in the [[!WOT-ARCHITECTURE]]. As such, it has the same 
     structure of a <a>Thing Description</a> but it may omit some information. The example below shows a serialization of a 
     <a>ExposedThingInit</a> as a JSON object. It can be noticed that it is not a valid <a>Thing Description</a> because it misses the title, @context,
     security information, and forms fields. Nevertheless, it could be used by a runtime as an hint to instantiate


### PR DESCRIPTION
This PR introduces the new concept of a PartialTD defined in the architecture PR: https://github.com/w3c/wot-architecture/pull/577.
The changes are heavier than I thought therefore I'd like to receive some feedback about the direction that I am taking. 

As you can see I changed the argument type of the `produce` method to `PartialTD`. This is because a Thing Description is also an instance of a `PartialTD`; in fact, the validation algorithm would accept any valid TD. 

Another open point is how we transform a `PartialTD` to a valid `Thing Description`. I tried to sketch an algorithm in this PR; please have look.

Notice finally, how these changes affect the construction of an `ExposedThing`. Now the constructor has first to transform the `PartialTD` and then extend the obtained TD with the default values.  


Fixes #287


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/relu91/wot-scripting-api/pull/289.html" title="Last updated on Feb 17, 2021, 2:48 PM UTC (5b7b6c8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/289/ef9c211...relu91:5b7b6c8.html" title="Last updated on Feb 17, 2021, 2:48 PM UTC (5b7b6c8)">Diff</a>