### PR TITLE
fix: PropertyReadHandler returning promise with InteractionInput

### DIFF
--- a/index.html
+++ b/index.html
@@ -2057,7 +2057,7 @@
         ThingDescription getThingDescription();
       };
 
-      callback PropertyReadHandler = Promise&lt;any&gt;(
+      callback PropertyReadHandler = Promise&lt;InteractionInput&gt;(
               optional InteractionOptions options = null);
 
       callback PropertyWriteHandler = Promise&lt;undefined&gt;(

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -290,13 +290,13 @@ declare namespace WoT {
         getThingDescription(): ThingDescription;
     }
 
-    export type PropertyReadHandler = (options?: InteractionOptions) => Promise<any>;
+    export type PropertyReadHandler = (options?: InteractionOptions) => Promise<InteractionInput>;
 
-    export type PropertyWriteHandler = (value: InteractionOutput, options?: InteractionOptions) => Promise<any>;
+    export type PropertyWriteHandler = (value: InteractionOutput, options?: InteractionOptions) => Promise<undefined>;
 
     export type ActionHandler = (params: InteractionOutput, options?: InteractionOptions) => Promise<InteractionInput>;
 
-    export type EventSubscriptionHandler = (options?: InteractionOptions) => Promise<void>;
+    export type EventSubscriptionHandler = (options?: InteractionOptions) => Promise<undefined>;
 
     export type EventListenerHandler = () => Promise<InteractionInput>;
 

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -292,11 +292,11 @@ declare namespace WoT {
 
     export type PropertyReadHandler = (options?: InteractionOptions) => Promise<InteractionInput>;
 
-    export type PropertyWriteHandler = (value: InteractionOutput, options?: InteractionOptions) => Promise<undefined>;
+    export type PropertyWriteHandler = (value: InteractionOutput, options?: InteractionOptions) => Promise<void>;
 
     export type ActionHandler = (params: InteractionOutput, options?: InteractionOptions) => Promise<InteractionInput>;
 
-    export type EventSubscriptionHandler = (options?: InteractionOptions) => Promise<undefined>;
+    export type EventSubscriptionHandler = (options?: InteractionOptions) => Promise<void>;
 
     export type EventListenerHandler = () => Promise<InteractionInput>;
 

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wot-typescript-definitions",
-  "version": "0.8.0-SNAPSHOT.8",
+  "version": "0.8.0-SNAPSHOT.9",
   "description": "TypeScript definitions for the W3C WoT Scripting API",
   "author": "W3C Web of Things Working Group",
   "license": "W3C-20150513",


### PR DESCRIPTION
see https://github.com/w3c/wot-scripting-api/issues/290
aligns TS definitions also (no NPM publish yet)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-scripting-api/pull/291.html" title="Last updated on Jan 25, 2021, 1:26 PM UTC (c7fe51d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/291/6c88d6b...danielpeintner:c7fe51d.html" title="Last updated on Jan 25, 2021, 1:26 PM UTC (c7fe51d)">Diff</a>