### PR TITLE
Fix sync action 

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -40,8 +40,8 @@ jobs:
         if: ${{ ! steps.diff.outputs.changed }}
         uses: EndBug/add-and-commit@v7
         with: 
-          # focus only on the schema just to be sure
-          add: 'typescript/schema'
+          # focus only on the schema and the generated file just to be sure
+          add: '["typescript/schema","typescript/thing-description.d.ts"]'
           author_name: action_sync
           message: 'chore(typescript): sync json schema from wot-thing-description.git'
       - uses: JasonEtco/create-an-issue@v2

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -21,7 +21,7 @@
   "types": "index.d.ts",
   "dependencies": {},
   "scripts": {
-    "build": "json2ts schema/td-json-schema-validation.json | sed -e 's/WoTTDSchema16February2021/ThingDescription/' > thing-description.d.ts"
+    "build": "json2ts schema/td-json-schema-validation.json | sed -e 's/WoTTDSchema02June2021/ThingDescription/' > thing-description.d.ts"
   },
   "devDependencies": {
     "json-schema-to-typescript": "^10.1.4"

--- a/typescript/thing-description.d.ts
+++ b/typescript/thing-description.d.ts
@@ -9,7 +9,7 @@ export type Title = string;
 export type TypeDeclaration = string | string[];
 export type Description = string;
 export type AnyUri = string;
-export type Subprotocol = "longpoll" | "websub" | "sse";
+export type Subprotocol = string;
 export type Security = string[] | string;
 export type Scopes = string[] | string;
 export type LinkElement = BaseLinkElement & {
@@ -18,7 +18,7 @@ export type LinkElement = BaseLinkElement & {
   [k: string]: unknown;
 };
 export type IconLinkElement = BaseLinkElement & {
-  rel?: "icon";
+  rel: "icon";
   sizes?: string;
   [k: string]: unknown;
 };
@@ -37,7 +37,7 @@ export type SecurityScheme =
       descriptions?: Descriptions;
       proxy?: AnyUri;
       scheme: "combo";
-      oneOf?: [string, string, ...string[]];
+      oneOf: [string, string, ...string[]];
       [k: string]: unknown;
     }
   | {
@@ -46,7 +46,7 @@ export type SecurityScheme =
       descriptions?: Descriptions;
       proxy?: AnyUri;
       scheme: "combo";
-      allOf?: [string, string, ...string[]];
+      allOf: [string, string, ...string[]];
       [k: string]: unknown;
     }
   | {
@@ -130,9 +130,9 @@ export type ThingContext =
 export type ThingContextW3CUri = "https://www.w3.org/2019/wot/td/v1" | "http://www.w3.org/ns/td";
 
 /**
- * JSON Schema for validating TD instances against the TD model. TD instances can be with or without terms that have default values
+ * JSON Schema for validating TD instances against the TD information model. TD instances can be with or without terms that have default values
  */
-export interface ThingDescription {
+export interface WoTTDSchema02June2021 {
   id?: string;
   title: Title;
   titles?: Titles;
@@ -156,6 +156,9 @@ export interface ThingDescription {
   base?: AnyUri;
   securityDefinitions: {
     [k: string]: SecurityScheme;
+  };
+  schemaDefinitions?: {
+    [k: string]: DataSchema;
   };
   support?: AnyUri;
   created?: string;
@@ -220,9 +223,7 @@ export interface FormElementProperty {
   };
   additionalResponses?: {
     contentType?: string;
-    schema?: {
-      [k: string]: DataSchema;
-    };
+    schema?: string;
     [k: string]: unknown;
   }[];
   [k: string]: unknown;
@@ -287,9 +288,7 @@ export interface FormElementAction {
   };
   additionalResponses?: {
     contentType?: string;
-    schema?: {
-      [k: string]: DataSchema;
-    };
+    schema?: string;
     [k: string]: unknown;
   }[];
   [k: string]: unknown;
@@ -323,9 +322,7 @@ export interface FormElementEvent {
   };
   additionalResponses?: {
     contentType?: string;
-    schema?: {
-      [k: string]: DataSchema;
-    };
+    schema?: string;
     [k: string]: unknown;
   }[];
   [k: string]: unknown;
@@ -367,9 +364,7 @@ export interface FormElementRoot {
   };
   additionalResponses?: {
     contentType?: string;
-    schema?: {
-      [k: string]: DataSchema;
-    };
+    schema?: string;
     [k: string]: unknown;
   }[];
   [k: string]: unknown;

--- a/typescript/thing-description.d.ts
+++ b/typescript/thing-description.d.ts
@@ -132,7 +132,7 @@ export type ThingContextW3CUri = "https://www.w3.org/2019/wot/td/v1" | "http://w
 /**
  * JSON Schema for validating TD instances against the TD information model. TD instances can be with or without terms that have default values
  */
-export interface WoTTDSchema02June2021 {
+export interface ThingDescription {
   id?: string;
   title: Title;
   titles?: Titles;


### PR DESCRIPTION
Just noticed that the GitHub action did not update the ts file generated but only the schema. There is still an issue with the name of the schema that needs to manually (using bash) replaced. I'll open a PR on the TD repo to use a version field instead of putting it in the title. 