### PR TITLE
Add NotFoundError for consumer algorithms

### DIFF
--- a/index.html
+++ b/index.html
@@ -1281,6 +1281,10 @@
             |propertyName|.
           </li>
           <li>
+            If |interaction| is  <code>undefined</code>, reject |promise| with a {{NotFoundError}}
+            and abort this steps.
+          </li>
+          <li>
             If |option|'s |formIndex| is defined, let |form| be the
             <a>Form</a> associated with |formIndex| in |interaction|'s |forms|
             array, otherwise let |form| be a <a>Form</a> in
@@ -1453,6 +1457,10 @@
             |propertyName|.
           </li>
           <li>
+            If |interaction| is <code>undefined</code>, reject |promise| with a {{NotFoundError}}
+            and abort this steps.
+          </li>
+          <li>
             If |option|'s |formIndex| is defined, let |form| be the
             <a>Form</a> associated with |formIndex| in |interaction|'s |forms|
             array, otherwise let |form| be a <a>Form</a> in
@@ -1613,6 +1621,10 @@
                 If |subscription|'s [[\form]] is failure, reject |promise| with a
                 {{SyntaxError}} and abort these steps.
               </li>
+              <li>
+                If |subscription|'s [[\interaction]] is <code>undefined</code>, reject |promise| with a {{NotFoundError}}
+                and abort this steps.
+              </li>
             </ul>
           </li>
           <li>
@@ -1682,6 +1694,10 @@
           <li>
             Let |interaction| be the value of [[\td]]'s |actions|'s
             |actionName|.
+          </li>
+          <li>
+            If |interaction| is <code>undefined</code>, reject |promise| with a {{NotFoundError}}
+            and abort this steps.
           </li>
           <li>
             If |option|'s |formIndex| is defined, let |form| be the
@@ -1763,6 +1779,10 @@
               <li>
                 If |subscription|'s [[\form]] is failure, reject |promise| with a
                 {{SyntaxError}} and abort these steps.
+              </li>
+              <li>
+                If |subscription|'s [[\interaction]] is <code>undefined</code>, reject |promise| with a {{NotFoundError}}
+                and abort this steps.
               </li>
             </ul>
           </li>


### PR DESCRIPTION
Might fix #334. I looked through the document and it seems that we just left consumer side algorithms without NotFoundError. In ExposedThings we already provide a dedicated step to throw NotFoundErrors.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/relu91/wot-scripting-api/pull/339.html" title="Last updated on Sep 20, 2021, 9:14 AM UTC (7411767)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/339/dfaed06...relu91:7411767.html" title="Last updated on Sep 20, 2021, 9:14 AM UTC (7411767)">Diff</a>