### PR TITLE
refactor: move section "Terminology and conventions" right after "Conformance"

### DIFF
--- a/index.html
+++ b/index.html
@@ -362,6 +362,99 @@
       Implementations that use TypeScript or ECMAScript in a runtime to implement the APIs defined in this document MUST implement them in a manner consistent with the TypeScript Bindings defined in the TypeScript specification [[!TYPESCRIPT]].
     </p>
   </section>
+  
+  <section> <h2>Terminology and conventions</h2>
+    <p>
+      The generic WoT terminology is defined in [[!WOT-ARCHITECTURE]]: <dfn data-lt="Things">Thing</dfn>, <dfn data-lt="Thing Descriptions">Thing Description</dfn> (in short <dfn>TD</dfn>), <dfn>Partial TD</dfn>, <dfn>Web of Things</dfn> (in short <b><i>WoT</i></b>),  <dfn>WoT Interface</dfn>, <dfn>Protocol Bindings</dfn>, <dfn>WoT Runtime</dfn>, <dfn data-lt="consume|consume a TD|consuming a TD">Consuming a Thing Description</dfn>, <dfn>Thing Directory</dfn>, <dfn data-lt="Properties">Property</dfn>, <dfn data-lt="Actions">Action</dfn>, <dfn data-lt="Events|WoT-Event">Event</dfn>,
+      <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#dataschema">
+        <dfn>DataSchema</dfn></a>, <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#form"><dfn data-lt="Forms">Form</dfn></a>,
+        <a href="https://w3c.github.io/wot-thing-description/#securityscheme"><dfn>SecurityScheme</dfn></a>, <a href="https://w3c.github.io/wot-thing-description/#nosecurityscheme"><dfn>NoSecurityScheme</dfn></a> etc.
+    </p>
+    <p>
+      <dfn data-plurals="WoT Interactions">WoT Interaction</dfn> is a synonym for <a href="https://www.w3.org/TR/2020/WD-wot-architecture11-20201124/#dfn-interaction-affordance"><dfn>Interaction Affordance</dfn></a>.
+      An <a>Interaction Affordance</a> (or shortly, affordance) is the term used in [[!WOT-TD]]
+      when referring to <a>Thing</a> capabilities, as explained in
+      <a href="https://github.com/w3c/wot-thing-description/issues/282">TD issue 282</a>.
+      However, this term is not well understood outside the <a>TD</a> semantic context.
+      Hence for the sake of readability, this document will use the previous term
+      <a>WoT interaction</a> or, simply, <em>interaction</em> instead.
+    </p>
+    <p>
+      <dfn>WoT network interface</dfn> synonym for <a>WoT Interface</a>
+    </p>
+    <p>
+      <dfn>JSON-LD</dfn> is defined in [[!JSON-LD]] as a JSON document that is augmented with support for Linked Data.
+    </p>
+    <p>
+      <dfn>JSON Schema</dfn> is defined in <a href="https://json-schema.org/specification.html">these specifications</a>.
+    </p>
+    <p>
+      The terms
+      <dfn data-cite="!URL#concept-url">URL</dfn>,
+      <dfn data-cite="!URL#concept-url-scheme">URL scheme</dfn>,
+      <dfn data-cite="!URL#concept-url-host">URL host</dfn>,
+      <dfn data-cite="!URL#concept-url-path">URL path</dfn>,
+      <dfn data-cite="!URL#concept-url">URL record</dfn>,
+      <dfn data-cite="!URL#url-parsing">parse a URL</dfn>,
+      <dfn data-cite="!URL#absolute-url-string">absolute-URL string</dfn>,
+      <dfn data-cite="!URL#path-absolute-url-string">path-absolute-URL string</dfn>,
+      <dfn data-cite="!URL#concept-basic-url-parser">basic URL parser</dfn>
+      are defined in [[!URL]].
+    </p>
+    <p>
+      The terms
+      <dfn data-cite="!MIMESNIFF#mime-type">MIME type</dfn>,
+      <dfn data-cite="!MIMESNIFF#parsing-a-mime-type">Parsing a MIME type</dfn>,
+      <dfn data-cite="!MIMESNIFF#serializing-a-mime-type">Serializing a MIME type</dfn>,
+      <dfn data-cite="!MIMESNIFF#valid-mime-type">valid MIME type string</dfn>,
+      <dfn data-cite="!MIMESNIFF#json-mime-type">JSON MIME type</dfn>
+      are defined in [[!MIMESNIFF]].
+    </p>
+    <p>
+      The terms
+      <dfn data-cite="!ENCODING#utf-8">UTF-8 encoding</dfn>,
+      <dfn data-cite="!ENCODING#utf-8-decode">UTF-8 decode</dfn>,
+      <dfn data-cite="!ENCODING#encode">encode</dfn>,
+      <dfn data-cite="!ENCODING#decode">decode</dfn>
+      are defined in [[!ENCODING]].
+    </p>
+    <p>
+      <dfn data-cite="!INFRA#string">string</dfn>,
+      <dfn data-cite="!INFRA#parse-json-bytes-to-a-javascript-value">parse JSON from bytes</dfn> and
+      <dfn data-cite="!INFRA#serialize-a-javascript-value-to-json-bytes">serialize JSON to bytes</dfn>,
+      are defined in [[!INFRA]].
+    </p>
+    <p>
+      <dfn data-cite="!ECMASCRIPT#sec-promise-objects">{{Promise}}</dfn>,
+      <dfn data-cite="!ECMASCRIPT#sec-error-objects">Error</dfn>,
+      <dfn data-cite="!ECMASCRIPT#sec-json-object">JSON</dfn>,
+      <dfn data-cite="!ECMASCRIPT#sec-json.stringify">JSON.stringify</dfn>,
+      <dfn data-cite="!ECMASCRIPT#sec-json.parse">JSON.parse</dfn>,
+      <dfn data-cite="!ECMASCRIPT#sec-object-internal-methods-and-internal-slots">internal method</dfn> and
+      <dfn data-cite="!ECMASCRIPT#sec-object-internal-methods-and-internal-slots">internal slot</dfn> are defined in [[!ECMASCRIPT]].
+    </p>
+    <p>
+      The terms
+      <dfn data-cite="!HTML#browsing-context">browsing context</dfn>,
+      <dfn data-cite="!HTML#top-level-browsing-context">top-level browsing context</dfn>,
+      <dfn data-cite="!HTML#global-object">global object</dfn>,
+      <dfn data-cite="!HTML#current-settings-object">current settings object</dfn>,
+      executing algorithms <dfn data-cite="!HTML#in-parallel">in parallel</dfn>
+       are defined in [[!HTML5]] and are used in the context of browser implementations.
+    </p>
+    <p>
+      The term
+      <a href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#secure-context">
+      <dfn>secure context</dfn></a> is defined in [[!WEBAPPSEC]].
+    </p>
+    <p>
+      <dfn>IANA media type</dfn>s (formerly known as MIME types) are defined in
+      <a href="http://tools.ietf.org/html/rfc2046">RFC2046</a>.
+    </p>
+    <p>
+      The terms <dfn>hyperlink reference</dfn> and <dfn>relation type</dfn> are defined in [[!HTML5]] and <a href="https://tools.ietf.org/html/rfc8288">RFC8288</a>.
+    </p>
+  </section>
 
   <section>
     <h2>The <dfn>ThingDescription</dfn> type</h2>
@@ -3938,99 +4031,6 @@
       </section>
 
     </section>
-  </section>
-
-  <section> <h2>Terminology and conventions</h2>
-    <p>
-      The generic WoT terminology is defined in [[!WOT-ARCHITECTURE]]: <dfn data-lt="Things">Thing</dfn>, <dfn data-lt="Thing Descriptions">Thing Description</dfn> (in short <dfn>TD</dfn>), <dfn>Partial TD</dfn>, <dfn>Web of Things</dfn> (in short <b><i>WoT</i></b>),  <dfn>WoT Interface</dfn>, <dfn>Protocol Bindings</dfn>, <dfn>WoT Runtime</dfn>, <dfn data-lt="consume|consume a TD|consuming a TD">Consuming a Thing Description</dfn>, <dfn>Thing Directory</dfn>, <dfn data-lt="Properties">Property</dfn>, <dfn data-lt="Actions">Action</dfn>, <dfn data-lt="Events|WoT-Event">Event</dfn>,
-      <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#dataschema">
-        <dfn>DataSchema</dfn></a>, <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#form"><dfn data-lt="Forms">Form</dfn></a>,
-        <a href="https://w3c.github.io/wot-thing-description/#securityscheme"><dfn>SecurityScheme</dfn></a>, <a href="https://w3c.github.io/wot-thing-description/#nosecurityscheme"><dfn>NoSecurityScheme</dfn></a> etc.
-    </p>
-    <p>
-      <dfn data-plurals="WoT Interactions">WoT Interaction</dfn> is a synonym for <a href="https://www.w3.org/TR/2020/WD-wot-architecture11-20201124/#dfn-interaction-affordance"><dfn>Interaction Affordance</dfn></a>.
-      An <a>Interaction Affordance</a> (or shortly, affordance) is the term used in [[!WOT-TD]]
-      when referring to <a>Thing</a> capabilities, as explained in
-      <a href="https://github.com/w3c/wot-thing-description/issues/282">TD issue 282</a>.
-      However, this term is not well understood outside the <a>TD</a> semantic context.
-      Hence for the sake of readability, this document will use the previous term
-      <a>WoT interaction</a> or, simply, <em>interaction</em> instead.
-    </p>
-    <p>
-      <dfn>WoT network interface</dfn> synonym for <a>WoT Interface</a>
-    </p>
-    <p>
-      <dfn>JSON-LD</dfn> is defined in [[!JSON-LD]] as a JSON document that is augmented with support for Linked Data.
-    </p>
-    <p>
-      <dfn>JSON Schema</dfn> is defined in <a href="https://json-schema.org/specification.html">these specifications</a>.
-    </p>
-    <p>
-      The terms
-      <dfn data-cite="!URL#concept-url">URL</dfn>,
-      <dfn data-cite="!URL#concept-url-scheme">URL scheme</dfn>,
-      <dfn data-cite="!URL#concept-url-host">URL host</dfn>,
-      <dfn data-cite="!URL#concept-url-path">URL path</dfn>,
-      <dfn data-cite="!URL#concept-url">URL record</dfn>,
-      <dfn data-cite="!URL#url-parsing">parse a URL</dfn>,
-      <dfn data-cite="!URL#absolute-url-string">absolute-URL string</dfn>,
-      <dfn data-cite="!URL#path-absolute-url-string">path-absolute-URL string</dfn>,
-      <dfn data-cite="!URL#concept-basic-url-parser">basic URL parser</dfn>
-      are defined in [[!URL]].
-    </p>
-    <p>
-      The terms
-      <dfn data-cite="!MIMESNIFF#mime-type">MIME type</dfn>,
-      <dfn data-cite="!MIMESNIFF#parsing-a-mime-type">Parsing a MIME type</dfn>,
-      <dfn data-cite="!MIMESNIFF#serializing-a-mime-type">Serializing a MIME type</dfn>,
-      <dfn data-cite="!MIMESNIFF#valid-mime-type">valid MIME type string</dfn>,
-      <dfn data-cite="!MIMESNIFF#json-mime-type">JSON MIME type</dfn>
-      are defined in [[!MIMESNIFF]].
-    </p>
-    <p>
-      The terms
-      <dfn data-cite="!ENCODING#utf-8">UTF-8 encoding</dfn>,
-      <dfn data-cite="!ENCODING#utf-8-decode">UTF-8 decode</dfn>,
-      <dfn data-cite="!ENCODING#encode">encode</dfn>,
-      <dfn data-cite="!ENCODING#decode">decode</dfn>
-      are defined in [[!ENCODING]].
-    </p>
-    <p>
-      <dfn data-cite="!INFRA#string">string</dfn>,
-      <dfn data-cite="!INFRA#parse-json-bytes-to-a-javascript-value">parse JSON from bytes</dfn> and
-      <dfn data-cite="!INFRA#serialize-a-javascript-value-to-json-bytes">serialize JSON to bytes</dfn>,
-      are defined in [[!INFRA]].
-    </p>
-    <p>
-      <dfn data-cite="!ECMASCRIPT#sec-promise-objects">{{Promise}}</dfn>,
-      <dfn data-cite="!ECMASCRIPT#sec-error-objects">Error</dfn>,
-      <dfn data-cite="!ECMASCRIPT#sec-json-object">JSON</dfn>,
-      <dfn data-cite="!ECMASCRIPT#sec-json.stringify">JSON.stringify</dfn>,
-      <dfn data-cite="!ECMASCRIPT#sec-json.parse">JSON.parse</dfn>,
-      <dfn data-cite="!ECMASCRIPT#sec-object-internal-methods-and-internal-slots">internal method</dfn> and
-      <dfn data-cite="!ECMASCRIPT#sec-object-internal-methods-and-internal-slots">internal slot</dfn> are defined in [[!ECMASCRIPT]].
-    </p>
-    <p>
-      The terms
-      <dfn data-cite="!HTML#browsing-context">browsing context</dfn>,
-      <dfn data-cite="!HTML#top-level-browsing-context">top-level browsing context</dfn>,
-      <dfn data-cite="!HTML#global-object">global object</dfn>,
-      <dfn data-cite="!HTML#current-settings-object">current settings object</dfn>,
-      executing algorithms <dfn data-cite="!HTML#in-parallel">in parallel</dfn>
-       are defined in [[!HTML5]] and are used in the context of browser implementations.
-    </p>
-    <p>
-      The term
-      <a href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#secure-context">
-      <dfn>secure context</dfn></a> is defined in [[!WEBAPPSEC]].
-    </p>
-    <p>
-      <dfn>IANA media type</dfn>s (formerly known as MIME types) are defined in
-      <a href="http://tools.ietf.org/html/rfc2046">RFC2046</a>.
-    </p>
-    <p>
-      The terms <dfn>hyperlink reference</dfn> and <dfn>relation type</dfn> are defined in [[!HTML5]] and <a href="https://tools.ietf.org/html/rfc8288">RFC8288</a>.
-    </p>
   </section>
 
   <section class="appendix">

--- a/index.html
+++ b/index.html
@@ -808,7 +808,7 @@
       (defined in [[WoT-TD]]) of the payload as a {{JSON}} object, initially `null`.
     </p>
     <p>
-      The <dfn>[[\value]]</dfn> internal slot represents the parsed value of
+      The <dfn data-lt="value">[[\value]]</dfn> internal slot represents the parsed value of
       the <a>WoT Interaction</a>, initially `undefined` (note that `null` is a
       valid value).
     </p>

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
             ]
           },
         ],
-        xref: ["web-platform", "streams", "wot-architecture", "wot-thing-description", "wot-binding-templates"],
+        xref: ["web-platform", "streams", "wot-architecture", "wot-thing-description", "wot-binding-templates", "html", "infra"],
         localBiblio: {
           "WOT-ARCHITECTURE" : {
             href:"https://www.w3.org/TR/2020/WD-wot-architecture11-20201124/",
@@ -380,7 +380,7 @@
       <a>WoT interaction</a> or, simply, <em>interaction</em> instead.
     </p>
     <p>
-      <dfn>WoT network interface</dfn> synonym for <a>WoT Interface</a>
+      <dfn>WoT network interface</dfn> synonym for <a>WoT Interface</a>.
     </p>
     <p>
       <dfn>JSON-LD</dfn> is defined in [[!JSON-LD]] as a JSON document that is augmented with support for Linked Data.
@@ -388,6 +388,7 @@
     <p>
       <dfn>JSON Schema</dfn> is defined in <a href="https://json-schema.org/specification.html">these specifications</a>.
     </p>
+	<!--
     <p>
       The terms
       <dfn data-cite="!URL#concept-url">URL</dfn>,
@@ -424,6 +425,7 @@
       <dfn data-cite="!INFRA#serialize-a-javascript-value-to-json-bytes">serialize JSON to bytes</dfn>,
       are defined in [[!INFRA]].
     </p>
+	-->
     <p>
       <dfn data-cite="!ECMASCRIPT#sec-promise-objects">{{Promise}}</dfn>,
       <dfn data-cite="!ECMASCRIPT#sec-error-objects">Error</dfn>,
@@ -433,6 +435,7 @@
       <dfn data-cite="!ECMASCRIPT#sec-object-internal-methods-and-internal-slots">internal method</dfn> and
       <dfn data-cite="!ECMASCRIPT#sec-object-internal-methods-and-internal-slots">internal slot</dfn> are defined in [[!ECMASCRIPT]].
     </p>
+	<!--
     <p>
       The terms
       <dfn data-cite="!HTML#browsing-context">browsing context</dfn>,
@@ -454,6 +457,7 @@
     <p>
       The terms <dfn>hyperlink reference</dfn> and <dfn>relation type</dfn> are defined in [[!HTML5]] and <a href="https://tools.ietf.org/html/rfc8288">RFC8288</a>.
     </p>
+	-->
   </section>
 
   <section>
@@ -543,7 +547,7 @@
       Belongs to the <a>WoT Consumer</a> conformance class. Expects an |td:ThingDescription| argument and returns a {{Promise}} that resolves with a {{ConsumedThing}} object that represents a client interface to operate with the <a>Thing</a>. The method MUST run the following steps:
       <ol>
         <li>
-          Return a {{Promise}} |promise:Promise| and execute the next steps <a>in parallel</a>.
+          Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
         </li>
         <li>
           If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
@@ -590,7 +594,7 @@
       The method MUST run the following steps:
       <ol>
         <li>
-          Return a {{Promise}} |promise:Promise| and execute the next steps <a>in parallel</a>.
+          Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
         </li>
         <li>
           If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
@@ -819,7 +823,7 @@
       <ol>
         <li>
           Return a {{Promise}} |promise:Promise| and execute the next steps
-          <a>in parallel</a>.
+          [=in parallel=].
         </li>
         <li>
           If the value of the <a>[[\value]]</a> <a>internal slot</a> is not
@@ -877,7 +881,7 @@
       <ol>
         <li>
           Return a {{Promise}} |promise:Promise| and execute the next steps
-          <a>in parallel</a>.
+          [=in parallel=].
         </li>
         <li>
           If |data| is not {{ReadableStream}} or if |dataUsed| is `true`,
@@ -1362,7 +1366,7 @@
         <ol>
           <li>
             Return a {{Promise}} |promise:Promise| and execute the next steps
-            <a>in parallel</a>.
+            [=in parallel=].
           </li>
           <li>
             If invoking this method is not allowed for the current scripting
@@ -1423,7 +1427,7 @@
         The method MUST run the following steps:
         <ol>
           <li>
-            Return a {{Promise}} |promise:Promise| and execute the next steps <a>in parallel</a>.
+            Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
           </li>
           <li>
             If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
@@ -1482,7 +1486,7 @@
         The method MUST run the following steps:
         <ol>
           <li>
-            Return a {{Promise}} |promise:Promise| and execute the next steps <a>in parallel</a>.
+            Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
           </li>
           <li>
             If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
@@ -1540,7 +1544,7 @@
         The method MUST run the following steps:
         <ol>
           <li>
-            Return a {{Promise}} |promise:Promise| and execute the next steps <a>in parallel</a>.
+            Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
           </li>
           <li>
             If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
@@ -1602,7 +1606,7 @@
         <ol>
           <li>
             Return a {{Promise}} |promise:Promise| and execute the next steps
-            <a>in parallel</a>.
+            [=in parallel=].
           </li>
           <li>
             If invoking this method is not allowed for the current scripting
@@ -1676,7 +1680,7 @@
         The method MUST run the following steps:
         <ol>
           <li>
-            Return a {{Promise}} |promise:Promise| and execute the next steps <a>in parallel</a>.
+            Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
           </li>
           <li>
             If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
@@ -1779,7 +1783,7 @@
         The method MUST run the following steps:
         <ol>
           <li>
-            Return a {{Promise}} |promise:Promise| and execute the next steps <a>in parallel</a>.
+            Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
           </li>
           <li>
             If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
@@ -1835,7 +1839,7 @@
         The method MUST run the following steps:
         <ol>
           <li>
-            Return a {{Promise}} |promise:Promise| and execute the next steps <a>in parallel</a>.
+            Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
           </li>
           <li>
             If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
@@ -2061,7 +2065,7 @@
           <ol>
             <li>
               Return a {{Promise}} |promise:Promise| and execute the next steps
-              <a>in parallel</a>.
+              [=in parallel=].
             </li>
             <li>
               If invoking this method is not allowed for the current scripting
@@ -2768,7 +2772,7 @@
         The method MUST run the following steps:
         <ol>
           <li>
-            Return a {{Promise}} |promise:Promise| and execute the next steps <a>in parallel</a>.
+            Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
           </li>
           <li>
             If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
@@ -3357,7 +3361,7 @@
         The method MUST run the following steps:
         <ol>
           <li>
-            Return a {{Promise}} |promise:Promise| and execute the next steps <a>in parallel</a>.
+            Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
           </li>
           <li>
             If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
@@ -3386,7 +3390,7 @@
         Start serving external requests for the <a>Thing</a>, so that <a>WoT Interactions</a> using <a>Properties</a>, <a>Action</a>s and <a>Event</a>s will be possible. The method MUST run the following steps:
         <ol>
           <li>
-            Return a {{Promise}} |promise:Promise| and execute the next steps <a>in parallel</a>.
+            Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
           </li>
           <li>
             If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
@@ -3435,7 +3439,7 @@
         Stop serving external requests for the <a>Thing</a> and destroy the object. Note that eventual unregistering should be done before invoking this method. The method MUST run the following steps:
         <ol>
           <li>
-            Return a {{Promise}} |promise:Promise| and execute the next steps <a>in parallel</a>.
+            Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
           </li>
           <li>
             If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
@@ -3817,7 +3821,7 @@
         Provides the next discovered {{ThingDescription}} object. The method MUST run the following steps:
         <ol>
           <li>
-            Return a {{Promise}} |promise:Promise| and execute the next steps <a>in parallel</a>.
+            Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
           </li>
           <li>
             If the <a href="#dom-thingdiscovery-active">active</a> property is `true`, wait until the <a>discovery results</a> <a>internal slot</a> is not empty.


### PR DESCRIPTION
resolves part#1 of https://github.com/w3c/wot-scripting-api/issues/342


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-scripting-api/pull/353.html" title="Last updated on Nov 29, 2021, 3:39 PM UTC (132fd6d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/353/ad7a37a...danielpeintner:132fd6d.html" title="Last updated on Nov 29, 2021, 3:39 PM UTC (132fd6d)">Diff</a>