### PR TITLE
resolve ReSpec warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
         crEnd:                "",
         inlineCSS:            true,
         noIDLIn:              true,
+		noRecTrack:           true,
         editors: [
           { name: "Zoltan Kis", w3cid: "57789", company: "Intel", companyURL: "https://www.intel.com/" },
           { name: "Daniel Peintner", w3cid: "39497", company: "Siemens AG", companyURL: "https://www.siemens.com/" },

--- a/index.html
+++ b/index.html
@@ -384,9 +384,6 @@
       <dfn>WoT network interface</dfn> synonym for <a>WoT Interface</a>.
     </p>
     <p>
-      <dfn>JSON-LD</dfn> is defined in [[!JSON-LD]] as a JSON document that is augmented with support for Linked Data.
-    </p>
-    <p>
       <dfn>JSON Schema</dfn> is defined in <a href="https://json-schema.org/specification.html">these specifications</a>.
     </p>
 	<!--
@@ -471,8 +468,7 @@
       Represents a <a>Thing Description</a> (<a>TD</a>) as
       <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/">defined</a> in
       [[!WOT-TD]]. It is expected to be
-	  a <a href="https://infra.spec.whatwg.org/#parse-json-bytes-to-a-javascript-value">parsed JSON object</a> that is validated using  <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#json-schema-for-validation">JSON Schema validation</a>.
-	  <a>Thing Descriptions</a> are encoded in a JSON format that also allows <a>JSON-LD</a> processing.
+      a <a href="https://infra.spec.whatwg.org/#parse-json-bytes-to-a-javascript-value">parsed JSON object</a> that is validated using <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#json-schema-for-validation">JSON Schema validation</a>.
     </p>
     <section> <h3> Fetching a Thing Description</h3>
       <p>

--- a/index.html
+++ b/index.html
@@ -471,7 +471,8 @@
       Represents a <a>Thing Description</a> (<a>TD</a>) as
       <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/">defined</a> in
       [[!WOT-TD]]. It is expected to be
-      a <a href="https://infra.spec.whatwg.org/#parse-json-bytes-to-a-javascript-value">parsed JSON object</a> that is validated using <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#json-schema-for-validation">JSON Schema validation</a>.
+      a <a href="https://infra.spec.whatwg.org/#parse-json-bytes-to-a-javascript-value">parsed JSON object</a> that is validated using  <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#json-schema-for-validation">JSON Schema validation</a>.
+	  <a>Thing Descriptions</a> are encoded in a JSON format that also allows <a>JSON-LD</a> processing.
     </p>
     <section> <h3> Fetching a Thing Description</h3>
       <p>

--- a/index.html
+++ b/index.html
@@ -470,7 +470,8 @@
     <p>
       Represents a <a>Thing Description</a> (<a>TD</a>) as
       <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/">defined</a> in
-      [[!WOT-TD]]. It is expected to be a <a href="https://infra.spec.whatwg.org/#parse-json-bytes-to-a-javascript-value">parsed JSON object</a> that is validated using  <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#json-schema-for-validation">JSON Schema validation</a>.
+      [[!WOT-TD]]. It is expected to be
+	  a <a href="https://infra.spec.whatwg.org/#parse-json-bytes-to-a-javascript-value">parsed JSON object</a> that is validated using  <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#json-schema-for-validation">JSON Schema validation</a>.
 	  <a>Thing Descriptions</a> are encoded in a JSON format that also allows <a>JSON-LD</a> processing.
     </p>
     <section> <h3> Fetching a Thing Description</h3>

--- a/index.html
+++ b/index.html
@@ -470,8 +470,7 @@
     <p>
       Represents a <a>Thing Description</a> (<a>TD</a>) as
       <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/">defined</a> in
-      [[!WOT-TD]]. It is expected to be
-      a <a href="https://infra.spec.whatwg.org/#parse-json-bytes-to-a-javascript-value">parsed JSON object</a> that is validated using  <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#json-schema-for-validation">JSON Schema validation</a>.
+      [[!WOT-TD]]. It is expected to be a <a href="https://infra.spec.whatwg.org/#parse-json-bytes-to-a-javascript-value">parsed JSON object</a> that is validated using  <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#json-schema-for-validation">JSON Schema validation</a>.
 	  <a>Thing Descriptions</a> are encoded in a JSON format that also allows <a>JSON-LD</a> processing.
     </p>
     <section> <h3> Fetching a Thing Description</h3>

--- a/index.html
+++ b/index.html
@@ -316,7 +316,7 @@
     This specification used to be a Working Draft which was expected to become a W3C Recommendation. However, it is now a WG Note which contains informative statements only. Therefore we need to consider how to deal with the description within this Conformance section.</p>
 
     <p>
-      This specification describes the conformance criteria for the following classes of <dfn>user agent</dfn> (<dfn>UA</dfn>).
+      This specification describes the conformance criteria for the following classes of [= user agent =] (<dfn>UA</dfn>).
     </p>
     <p>
       Due to requirements of small embedded implementations, splitting WoT client and server interfaces was needed. Then, discovery is a distributed application, but typical scenarios have been covered by a generic discovery API in this specification. This resulted in using 3 conformance classes for a <a>UA</a> that implements this API, one for client, one for server, and one for discovery. An application that uses this API can introspect for the presence of the <code>consume()</code>, <code>produce()</code> and <code>discover()</code> methods on the <a>WoT API object</a> in order to determine which conformance class the <a>UA</a> implements.


### PR DESCRIPTION
fix: make clear that document is not on REC track

fixes https://github.com/w3c/wot-scripting-api/issues/365


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-scripting-api/pull/368.html" title="Last updated on Jan 31, 2022, 2:00 PM UTC (9acc6d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/368/c244340...danielpeintner:9acc6d7.html" title="Last updated on Jan 31, 2022, 2:00 PM UTC (9acc6d7)">Diff</a>