### PR TITLE
Generate types for unreachable definitions

### DIFF
--- a/typescript/thing-description/package.json
+++ b/typescript/thing-description/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/w3c/wot-scripting-api#readme",
   "scripts": {
-    "build": "json2ts schema/td-json-schema-validation.json > thing-description.d.ts"
+    "build": "json2ts --unreachableDefinitions --input schema/td-json-schema-validation.json  --output thing-description.d.ts"
   },
   "devDependencies": {
     "json-schema-to-typescript": "^10.1.4"

--- a/typescript/thing-description/thing-description.d.ts
+++ b/typescript/thing-description/thing-description.d.ts
@@ -5,37 +5,103 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "title".
+ */
 export type Title = string;
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "type_declaration".
+ */
 export type TypeDeclaration = string | string[];
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "description".
+ */
 export type Description = string;
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "form_element_property".
+ */
 export type FormElementProperty = FormElementBase;
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "anyUri".
+ */
 export type AnyUri = string;
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "subprotocol".
+ */
 export type Subprotocol = string;
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "security".
+ */
 export type Security = string[] | string;
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "scopes".
+ */
 export type Scopes = string[] | string;
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "additionalResponsesDefinition".
+ */
 export type AdditionalResponsesDefinition = {
   contentType?: string;
   schema?: string;
   success?: boolean;
   [k: string]: unknown;
 }[];
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "dataSchema-type".
+ */
 export type DataSchemaType =
   | ("boolean" | "integer" | "number" | "string" | "object" | "array" | "null")
   | ("boolean" | "integer" | "number" | "string" | "object" | "array" | "null")[];
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "multipleOfDefinition".
+ */
 export type MultipleOfDefinition = number;
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "form_element_action".
+ */
 export type FormElementAction = FormElementBase;
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "form_element_event".
+ */
 export type FormElementEvent = FormElementBase;
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "link_element".
+ */
 export type LinkElement = BaseLinkElement & {
   [k: string]: unknown;
-} & {
-  [k: string]: unknown;
 };
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "icon_link_element".
+ */
 export type IconLinkElement = BaseLinkElement & {
   rel: "icon";
   sizes?: string;
   [k: string]: unknown;
 };
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "form_element_root".
+ */
 export type FormElementRoot = FormElementBase;
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "securityScheme".
+ */
 export type SecurityScheme =
   | NoSecurityScheme
   | ComboSecurityScheme
@@ -45,6 +111,10 @@ export type SecurityScheme =
   | BearerSecurityScheme
   | PskSecurityScheme
   | OAuth2SecurityScheme;
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "comboSecurityScheme".
+ */
 export type ComboSecurityScheme =
   | {
       "@type"?: TypeDeclaration;
@@ -64,6 +134,10 @@ export type ComboSecurityScheme =
       allOf: [string, string, ...string[]];
       [k: string]: unknown;
     };
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "thing-context".
+ */
 export type ThingContext =
   | []
   | [
@@ -76,10 +150,19 @@ export type ThingContext =
       )[]
     ]
   | ThingContextW3CUri;
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "thing-context-w3c-uri".
+ */
 export type ThingContextW3CUri =
   | "https://www.w3.org/2019/wot/td/v1"
   | "http://www.w3.org/ns/td"
   | "https://www.w3.org/2022/wot/td/v1.1";
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "form".
+ */
+export type Form = FormElementProperty | FormElementAction | FormElementEvent | FormElementRoot;
 
 /**
  * JSON Schema for validating TD instances against the TD information model. TD instances can be with or without terms that have default values
@@ -120,9 +203,17 @@ export interface ThingDescription {
   "@context": ThingContext;
   [k: string]: unknown;
 }
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "titles".
+ */
 export interface Titles {
   [k: string]: string;
 }
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "property_element".
+ */
 export interface PropertyElement {
   "@type"?: TypeDeclaration;
   description?: Description;
@@ -159,9 +250,17 @@ export interface PropertyElement {
   required?: string[];
   [k: string]: unknown;
 }
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "descriptions".
+ */
 export interface Descriptions {
   [k: string]: string;
 }
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "form_element_base".
+ */
 export interface FormElementBase {
   op?: string | string[];
   href: AnyUri;
@@ -174,10 +273,18 @@ export interface FormElementBase {
   additionalResponses?: AdditionalResponsesDefinition;
   [k: string]: unknown;
 }
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "expectedResponse".
+ */
 export interface ExpectedResponse {
   contentType?: string;
   [k: string]: unknown;
 }
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "dataSchema".
+ */
 export interface DataSchema {
   "@type"?: TypeDeclaration;
   description?: Description;
@@ -211,6 +318,10 @@ export interface DataSchema {
   required?: string[];
   [k: string]: unknown;
 }
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "action_element".
+ */
 export interface ActionElement {
   "@type"?: TypeDeclaration;
   description?: Description;
@@ -227,6 +338,10 @@ export interface ActionElement {
   idempotent?: boolean;
   [k: string]: unknown;
 }
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "event_element".
+ */
 export interface EventElement {
   "@type"?: TypeDeclaration;
   description?: Description;
@@ -242,6 +357,10 @@ export interface EventElement {
   cancellation?: DataSchema;
   [k: string]: unknown;
 }
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "base_link_element".
+ */
 export interface BaseLinkElement {
   href: AnyUri;
   type?: string;
@@ -249,6 +368,10 @@ export interface BaseLinkElement {
   anchor?: AnyUri;
   [k: string]: unknown;
 }
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "noSecurityScheme".
+ */
 export interface NoSecurityScheme {
   "@type"?: TypeDeclaration;
   description?: Description;
@@ -257,6 +380,10 @@ export interface NoSecurityScheme {
   scheme: "nosec";
   [k: string]: unknown;
 }
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "basicSecurityScheme".
+ */
 export interface BasicSecurityScheme {
   "@type"?: TypeDeclaration;
   description?: Description;
@@ -267,6 +394,10 @@ export interface BasicSecurityScheme {
   name?: string;
   [k: string]: unknown;
 }
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "digestSecurityScheme".
+ */
 export interface DigestSecurityScheme {
   "@type"?: TypeDeclaration;
   description?: Description;
@@ -278,6 +409,10 @@ export interface DigestSecurityScheme {
   name?: string;
   [k: string]: unknown;
 }
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "apiKeySecurityScheme".
+ */
 export interface ApiKeySecurityScheme {
   "@type"?: TypeDeclaration;
   description?: Description;
@@ -288,6 +423,10 @@ export interface ApiKeySecurityScheme {
   name?: string;
   [k: string]: unknown;
 }
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "bearerSecurityScheme".
+ */
 export interface BearerSecurityScheme {
   "@type"?: TypeDeclaration;
   description?: Description;
@@ -301,6 +440,10 @@ export interface BearerSecurityScheme {
   name?: string;
   [k: string]: unknown;
 }
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "pskSecurityScheme".
+ */
 export interface PskSecurityScheme {
   "@type"?: TypeDeclaration;
   description?: Description;
@@ -310,6 +453,10 @@ export interface PskSecurityScheme {
   identity?: string;
   [k: string]: unknown;
 }
+/**
+ * This interface was referenced by `ThingDescription`'s JSON-Schema
+ * via the `definition` "oAuth2SecurityScheme".
+ */
 export interface OAuth2SecurityScheme {
   "@type"?: TypeDeclaration;
   description?: Description;


### PR DESCRIPTION
https://github.com/w3c/wot-thing-description/pull/1319 introduced a schema definition for `Form`. In principle, this new definition was added to let typescript users have a type for a generic form. Sadly, [json-schema-to-typescript](https://github.com/bcherny/json-schema-to-typescript) does not automatically do it but you have to enable it. This PR enables the generation of unreachable definitions. As you can see on the diff enabling such option causes also the generation of a long list of unwanted comments. I tried to get rid of them without any success. I'm waiting for [an answer](https://github.com/bcherny/json-schema-to-typescript/issues/428) from the main contributors to remove them, meanwhile, I think we can live with them. 