### PR TITLE
feat: reintroduce "local" discovery method

### DIFF
--- a/index.html
+++ b/index.html
@@ -3820,7 +3820,7 @@
             Request the underlying platform to start the discovery process, with the following parameters:
             <ul>
               <li>
-              If |filter|s <a href="#dom-thingfilter-method">|method|</a> is not defined or the value is `"local"`, use the widest discovery method supported by the underlying platform.
+              If |filter|s <a href="#dom-thingfilter-method">|method|</a> is not defined or the value is `"local"`, use all local discovery mechanisms supported by the underlying platform.
               </li>
               <li>
                 If |filter|s <a href="#dom-thingfilter-method">|method|</a> is `"directory"`, use the remote <a>Thing Directory</a> specified in |filter.url|.

--- a/index.html
+++ b/index.html
@@ -3751,6 +3751,9 @@
           "<dfn>directory</dfn>" for discovery based on a service provided by a
           <a>Thing Directory</a> specified by <a>ThingFilter</a>'s `url`.
         </li>
+        <li>
+          "<dfn>local</dfn>" for discovering <a>Thing</a>s defined in the same device or connected to the device by wired or wireless means.
+        </li>
       </ul>
     </section>
 
@@ -3761,7 +3764,7 @@
       </p>
       <pre class="idl">
         dictionary ThingFilter {
-          DiscoveryMethod method = "directory";
+          DiscoveryMethod method = "local";
           USVString? url;
           object? fragment;
           <!-- DOMString? query; -->
@@ -3817,7 +3820,10 @@
             Request the underlying platform to start the discovery process, with the following parameters:
             <ul>
               <li>
-                If |filter|s <a href="#dom-thingfilter-method">|method|</a> is not defined or is `"directory"`, use the remote <a>Thing Directory</a> specified in |filter.url|.
+              If |filter|s <a href="#dom-thingfilter-method">|method|</a> is not defined or the value is `"local"`, use the widest discovery method supported by the underlying platform.
+              </li>
+              <li>
+                If |filter|s <a href="#dom-thingfilter-method">|method|</a> is `"directory"`, use the remote <a>Thing Directory</a> specified in |filter.url|.
               </li>
               <li>
                 Otherwise if |filter|s <a href="#dom-thingfilter-method">|method|</a> is `"direct"`, use the remote <a>Thing</a> specified in |filter.url|.
@@ -3915,11 +3921,13 @@
       <p>
         The following example finds {{ThingDescription}} objects of <a>Thing</a>s that are exposed by local hardware, regardless how many instances of <a>WoT Runtime</a> it is running. Note that the discovery can end (become inactive) before the internal <a>discovery results</a> queue is emptied, so we need to continue reading {{ThingDescription}} objects until done. This is typical with local and directory type discoveries.
       </p>
-      <pre class="example" title="Fetch the Thing Description of a Thing">
-        let discovery = new ThingDiscovery({ method: "direct" });
+      <pre class="example" title="Discover Things exposed by local hardware">
+        let discovery = new ThingDiscovery({ method: "local" });
         do {
           let td = await discovery.next();
           console.log("Found Thing Description for " + td.title);
+          let thing = new ConsumedThing(td);
+          console.log("Thing name: " + thing.getThingDescription().title);
         } while (!discovery.done);
       </pre>
       <p>
@@ -3927,7 +3935,7 @@
       </p>
       <pre class="example" title="Discover Things via directory">
         let discoveryFilter = {
-          method: "directory", // default value, no need to specify
+          method: "directory",
           url: "http://directory.wotservice.org"
         };
         let discovery = new ThingDiscovery(discoveryFilter);


### PR DESCRIPTION
At the last meeting, we had a discussion regarding the reintroduction of the "local" discovery method to the specification, initiated by @mmccool. This PR provides a first starting point for further discussion, reusing text that was removed by https://github.com/w3c/wot-scripting-api/pull/316.

I think the direction of last meeting's discussion was that "local" should now also include multicast discovery and should return TDs from all supported sources that can be considered nearby in an automatic fashion. There is probably some distinction needed in this regard (for instance, where does the use of a CoRE Resource Directory fall into that is not part of the local network?) as well as the possibibility to configure which "submethods" provided by the implementation should actually be used and how.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 10, 2022, 8:19 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2FJKRhb%2Fwot-scripting-api%2F14cb907571a7a7c0a646b4873b59c3509b8749aa%2Findex.html%3FisPreview%3Dtrue)

```
📡 HTTP Error 429: https://rawcdn.githack.com/JKRhb/wot-scripting-api/14cb907571a7a7c0a646b4873b59c3509b8749aa/index.html
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/wot-scripting-api%23381.)._
</details>
