### PR TITLE
Pull before pushing in the CI

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -44,6 +44,7 @@ jobs:
           add: '["typescript/thing-description/schema","typescript/thing-description/thing-description.d.ts"]'
           author_name: action_sync
           message: 'chore(typescript): sync thing description json schema from wot-thing-description.git'
+          pull: '--rebase'
       - uses: JasonEtco/create-an-issue@v2
         if: ${{ ! steps.diff.outputs.changed }}
         env:
@@ -88,6 +89,7 @@ jobs:
           add: '["typescript/thing-model/schema","typescript/thing-model/thing-model.d.ts"]'
           author_name: action_sync
           message: 'chore(typescript): sync thing model json schema from wot-thing-description.git'
+          pull: '--rebase'
       - uses: JasonEtco/create-an-issue@v2
         if: ${{ ! steps.diff.outputs.changed }}
         env:


### PR DESCRIPTION
I would like to keep the two jobs parallel, therefore I've added a pull action before pushing to the upstream. In theory one of the two jobs might still push changes while the other has already pulled... but I want to give this a try. Fixes #382 