### PR TITLE
fix: add missing emitPropertyChange() method

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -549,7 +549,7 @@
     },
     "scripting-api": {
       "name": "wot-typescript-definitions",
-      "version": "0.8.0-SNAPSHOT.22",
+      "version": "0.8.0-SNAPSHOT.23",
       "license": "W3C-20150513",
       "devDependencies": {
         "json-schema-to-typescript": "^10.1.4"

--- a/typescript/scripting-api/index.d.ts
+++ b/typescript/scripting-api/index.d.ts
@@ -243,6 +243,12 @@ declare namespace WoT {
          * Returns a reference to the same object for supporting chaining.
          */
         setPropertyUnobserveHandler(name: string, handler: PropertyReadHandler): ExposedThing;
+		
+        /**
+         * Takes as arguments name denoting a Property name.
+         * Triggers emitting a notification to all observers. 
+         */
+        emitPropertyChange(name: string): void;
 
         /**
          * Takes name as string argument and handler as argument of type ActionHandler.

--- a/typescript/scripting-api/package.json
+++ b/typescript/scripting-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wot-typescript-definitions",
-  "version": "0.8.0-SNAPSHOT.22",
+  "version": "0.8.0-SNAPSHOT.23",
   "description": "TypeScript definitions for the W3C WoT Scripting API",
   "author": "W3C Web of Things Working Group",
   "license": "W3C-20150513",


### PR DESCRIPTION
Question: Did we simply miss it or was there a reason for leaving it out? 