### PR TITLE
feat!: add new Discovery Web IDL definitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -3762,8 +3762,8 @@
       </p>
       <pre class="idl">
         dictionary ThingFilter {
-          DiscoveryMethod method = "direct";
-          required USVString url;
+          DiscoveryMethod method = "directory";
+          USVString? url;
           object? fragment;
           <!-- DOMString? query; -->
         };

--- a/index.html
+++ b/index.html
@@ -3676,7 +3676,7 @@
     <pre class="idl">
       [SecureContext, Exposed=(Window,Worker)]
       interface ThingDiscovery {
-        constructor(ThingFilter filter);
+        constructor(optional ThingFilter filter = null);
         readonly attribute ThingFilter? filter;
         readonly attribute boolean active;
         readonly attribute boolean done;

--- a/index.html
+++ b/index.html
@@ -3691,9 +3691,6 @@
       The {{ThingDiscovery}} interface has a <code>next()</code> method and a <code>done</code> property, but it is not an <a href="https://tc39.es/proposal-async-iteration/">Iterable</a>. Look into <a href="https://github.com/w3c/wot-scripting-api/issues/177">Issue 177</a> for rationale.
     </p>
     <p>
-      The <dfn>discovery results</dfn> <a>internal slot</a> is an internal queue for temporarily storing the found {{ThingDescription}} objects until they are consumed by the application using the <a href="#the-next-method">next()</a> method. Implementations MAY optimize the size of this queue based on e.g. the available resources and the frequency of invoking the <a href="#the-next-method">next()</a> method.
-    </p>
-    <p>
       The <dfn>filter</dfn> property represents the discovery filter of type <a>ThingFilter</a> specified for the discovery.
     </p>
     <p>
@@ -3704,6 +3701,9 @@
     </p>
     <p>
       The <dfn>error</dfn> property represents the last error that occurred during the discovery process. Typically used for critical errors that stop discovery.
+    </p>
+    <p>
+      <!-- TODO: Mention AsyncIterator/AsyncIterable? -->
     </p>
 
     <section><h3>Constructing {{ThingDiscovery}}</h3>
@@ -3728,10 +3728,10 @@
         </ol>
       </div>
       <p>
-        The <a href="#the-start-method">start()</a> method sets <a href="#dom-thingdiscovery-active">active</a> to `true`. The <a href="#the-stop-method">stop()</a> method sets the <a href="#dom-thingdiscovery-active">active</a> property to |false|, but <a href="#dom-thingdiscovery-done">done</a> may be still `false` if there are {{ThingDescription}} objects in the <a>discovery results</a> not yet consumed with <a href="#the-next-method">next()</a>.
+        The <a href="#the-start-method">start()</a> method sets <a href="#dom-thingdiscovery-active">active</a> to `true`. The <a href="#the-stop-method">stop()</a> method sets the <a href="#dom-thingdiscovery-active">active</a> property to |false|, but <a href="#dom-thingdiscovery-done">done</a> may be still `false` if there are {{ThingDescription}} objects which can be yielded by the `Symbol.AsyncIterator`.
       </p>
       <p>
-         During successive calls of <a href="#the-next-method">next()</a>, the <a href="#dom-thingdiscovery-active">active</a> property may be `true` or `false`, but the <a href="#dom-thingdiscovery-done">done</a> property is set to `false` by <a href="#the-next-method">next()</a> only when both the <a href="#dom-thingdiscovery-active">active</a> property is `false` and <a>discovery results</a> is empty.
+         During successive calls of <a href="#the-next-method">next()</a>, the <a href="#dom-thingdiscovery-active">active</a> property may be `true` or `false`, but the <a href="#dom-thingdiscovery-done">done</a> property is set to `false` by <a href="#the-next-method">next()</a> only when both the <a href="#dom-thingdiscovery-active">active</a> property is `false` and the `done` property in the object yielded by `Symbol.AsyncIterator` is set to `true`.
       </p>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -3676,14 +3676,13 @@
     <pre class="idl">
       [SecureContext, Exposed=(Window,Worker)]
       interface ThingDiscovery {
-        constructor(optional ThingFilter filter = null);
+        constructor(ThingFilter filter);
         readonly attribute ThingFilter? filter;
         readonly attribute boolean active;
         readonly attribute boolean done;
         readonly attribute Error? error;
-        undefined start();
-        Promise&lt;ThingDescription&gt; next();
         undefined stop();
+        async iterable&lt;ThingDescription&gt;;
       };
     </pre>
     <p class="ednote">
@@ -3761,8 +3760,8 @@
       </p>
       <pre class="idl">
         dictionary ThingFilter {
-          DiscoveryMethod method = "directory";
-          USVString? url;
+          DiscoveryMethod method = "direct";
+          required USVString url;
           object? fragment;
           <!-- DOMString? query; -->
         };

--- a/index.html
+++ b/index.html
@@ -3728,10 +3728,10 @@
         </ol>
       </div>
       <p>
-        The <a href="#the-start-method">start()</a> method sets <a href="#dom-thingdiscovery-active">active</a> to `true`. The <a href="#the-stop-method">stop()</a> method sets the <a href="#dom-thingdiscovery-active">active</a> property to |false|, but <a href="#dom-thingdiscovery-done">done</a> may be still `false` if there are {{ThingDescription}} objects which can be yielded by the `Symbol.AsyncIterator`.
+        The <a href="#the-start-method">start()</a> method sets <a href="#dom-thingdiscovery-active">active</a> to `true`. The <a href="#the-stop-method">stop()</a> method sets the <a href="#dom-thingdiscovery-active">active</a> property to |false|, but <a href="#dom-thingdiscovery-done">done</a> may be still `false` if there are {{ThingDescription}} objects which can be yielded by the {{Symbol/asyncIterator}}.
       </p>
       <p>
-         During successive calls of <a href="#the-next-method">next()</a>, the <a href="#dom-thingdiscovery-active">active</a> property may be `true` or `false`, but the <a href="#dom-thingdiscovery-done">done</a> property is set to `false` by <a href="#the-next-method">next()</a> only when both the <a href="#dom-thingdiscovery-active">active</a> property is `false` and the `done` property in the object yielded by `Symbol.AsyncIterator` is set to `true`.
+         During successive calls of <a href="#the-next-method">next()</a>, the <a href="#dom-thingdiscovery-active">active</a> property may be `true` or `false`, but the <a href="#dom-thingdiscovery-done">done</a> property is set to `false` by <a href="#the-next-method">next()</a> only when both the <a href="#dom-thingdiscovery-active">active</a> property is `false` and the `done` property in the object yielded by the {{Symbol/asyncIterator}} is set to `true`.
       </p>
     </section>
 
@@ -3843,7 +3843,7 @@
                 If |filter|'s <a href="#dom-thingfilter-fragment">|fragment|</a> is defined, for each property defined in it, check if that property exists in |json|'s properties and has the same value. If this is `false` in any checks, discard |td| and continue the discovery process.
               </li>
               <li>
-                Otherwise return a `Symbol.AsyncIterator` and yield the |td|.
+                Otherwise return a {{Symbol/asyncIterator}} and yield the |td|.
               </li>
               <li>
                 At this point implementations MAY control the flow of the discovery process (depending on memory constraints, for instance temporarily stop discovery if the queue is getting too large, or resume discovery when the queue is emptied sufficiently).
@@ -3883,10 +3883,10 @@
             Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
           </li>
           <li>
-            If the <a href="#dom-thingdiscovery-active">active</a> property is `true`, call the `next` method on the Discovery object's `Symbol.AsyncIterator`.
+            If the <a href="#dom-thingdiscovery-active">active</a> property is `true`, call the `next` method on the Discovery object's {{Symbol/asyncIterator}}.
           </li>
           <li>
-            If the `value` property in the yielded result from the `Symbol.AsyncIterator` is undefined and the `done` property is set to `true`, set the <a href="#dom-thingdiscovery-done">done</a> property to `true` and reject |promise|.
+            If the `value` property in the yielded result from the {{Symbol/asyncIterator}} is undefined and the `done` property is set to `true`, set the <a href="#dom-thingdiscovery-done">done</a> property to `true` and reject |promise|.
           </li>
           <li>
             Resolve |promise| with |td| and abort these steps.
@@ -3914,7 +3914,7 @@
       <h3>Discovery Examples</h3>
       <p>
         The following example finds {{ThingDescription}} objects of <a>Thing</a>s that are exposed by local hardware, regardless how many instances of <a>WoT Runtime</a> it is running
-        Using the `Symbol.AsyncIterator` provided by the Discovery object, we can iterate asynchronously over the results and perform operations with the obtained {{ThingDescription}} objects.
+        Using the {{Symbol/asyncIterator}} provided by the Discovery object, we can iterate asynchronously over the results and perform operations with the obtained {{ThingDescription}} objects.
       </p>
       <pre class="example" title="Fetch the Thing Description of a Thing">
         let discovery = new ThingDiscovery({ method: "direct" });

--- a/index.html
+++ b/index.html
@@ -3833,6 +3833,7 @@
             <ol>
               <li>
                 Retrieve |td| as a JSON object using the <a>Protocol Binding</a> specified in the |filter.url| property.
+                In the case of an HTTP(S) Binding, this process could use the <a href="https://fetch.spec.whatwg.org/#fetch-api">Fetch API</a> for the |td|'s retrieval.
                 If that fails, set the <a href="#dom-thingdiscovery-error">error</a> property to {{SyntaxError}}, discard |td| and continue the discovery process.
               </li>
               <!--li>

--- a/index.html
+++ b/index.html
@@ -3681,6 +3681,8 @@
         readonly attribute boolean active;
         readonly attribute boolean done;
         readonly attribute Error? error;
+        undefined start();
+        Promise&lt;ThingDescription&gt; next();
         undefined stop();
         async iterable&lt;ThingDescription&gt;;
       };
@@ -3809,9 +3811,9 @@
               </li>
             </ul>
           </li-->
-          <li>
+          <!-- <li>
             Create the <a>discovery results</a> <a>internal slot</a> for storing discovered {{ThingDescription}} objects.
-          </li>
+          </li> -->
           <li>
             Request the underlying platform to start the discovery process, with the following parameters:
             <ul>
@@ -3830,7 +3832,8 @@
             Whenever a new <a>Thing Description</a> |td:ThingDescription| is discovered by the underlying platform, run the following sub-steps:
             <ol>
               <li>
-                <a href="https://fetch.spec.whatwg.org/#fetch-api">Fetch</a> |td| as a JSON object |json|. If that fails, set the <a href="#dom-thingdiscovery-error">error</a> property to {{SyntaxError}}, discard |td| and continue the discovery process.
+                Retrieve |td| as a JSON object using the <a>Protocol Binding</a> specified by the |filter|'s <dfn>url</dfn> property.
+                If that fails, set the <a href="#dom-thingdiscovery-error">error</a> property to {{SyntaxError}}, discard |td| and continue the discovery process.
               </li>
               <!--li>
                 If |filter|'s <a href="#dom-thingfilter-query">|query|</a> is defined, check if |json| is a match for the query. The matching algorithm is encapsulated by implementations. If that returns `false`, discard |td| and continue the discovery process.
@@ -3839,7 +3842,7 @@
                 If |filter|'s <a href="#dom-thingfilter-fragment">|fragment|</a> is defined, for each property defined in it, check if that property exists in |json|'s properties and has the same value. If this is `false` in any checks, discard |td| and continue the discovery process.
               </li>
               <li>
-                Otherwise add |td| to the <a>discovery results</a>.
+                Otherwise return an {{@@asyncIterator}} and yield the |td|.
               </li>
               <li>
                 At this point implementations MAY control the flow of the discovery process (depending on memory constraints, for instance temporarily stop discovery if the queue is getting too large, or resume discovery when the queue is emptied sufficiently).
@@ -3879,13 +3882,10 @@
             Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
           </li>
           <li>
-            If the <a href="#dom-thingdiscovery-active">active</a> property is `true`, wait until the <a>discovery results</a> <a>internal slot</a> is not empty.
+            If the <a href="#dom-thingdiscovery-active">active</a> property is `true`, call the `next` method on the Discovery object's Symbol.AsyncIterator.
           </li>
           <li>
-            If <a>discovery results</a> is empty and the <a href="#dom-thingdiscovery-active">active</a> property is `false`, set the <a href="#dom-thingdiscovery-done">done</a> property to `true` and reject |promise|.
-          </li>
-          <li>
-            Remove the first {{ThingDescription}} object |td| from <a>discovery results</a>.
+            If the `value` property in the yielded result from the Symbol.AsyncIterator is undefined and the `done` property is set to `true`, set the <a href="#dom-thingdiscovery-done">done</a> property to `true` and reject |promise|.
           </li>
           <li>
             Resolve |promise| with |td| and abort these steps.

--- a/index.html
+++ b/index.html
@@ -3832,7 +3832,7 @@
             Whenever a new <a>Thing Description</a> |td:ThingDescription| is discovered by the underlying platform, run the following sub-steps:
             <ol>
               <li>
-                Retrieve |td| as a JSON object using the <a>Protocol Binding</a> specified by the |filter|'s <dfn>url</dfn> property.
+                Retrieve |td| as a JSON object using the <a>Protocol Binding</a> specified in the |filter.url| property.
                 If that fails, set the <a href="#dom-thingdiscovery-error">error</a> property to {{SyntaxError}}, discard |td| and continue the discovery process.
               </li>
               <!--li>
@@ -3842,7 +3842,7 @@
                 If |filter|'s <a href="#dom-thingfilter-fragment">|fragment|</a> is defined, for each property defined in it, check if that property exists in |json|'s properties and has the same value. If this is `false` in any checks, discard |td| and continue the discovery process.
               </li>
               <li>
-                Otherwise return an {{@@asyncIterator}} and yield the |td|.
+                Otherwise return a `Symbol.AsyncIterator` and yield the |td|.
               </li>
               <li>
                 At this point implementations MAY control the flow of the discovery process (depending on memory constraints, for instance temporarily stop discovery if the queue is getting too large, or resume discovery when the queue is emptied sufficiently).
@@ -3882,10 +3882,10 @@
             Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
           </li>
           <li>
-            If the <a href="#dom-thingdiscovery-active">active</a> property is `true`, call the `next` method on the Discovery object's Symbol.AsyncIterator.
+            If the <a href="#dom-thingdiscovery-active">active</a> property is `true`, call the `next` method on the Discovery object's `Symbol.AsyncIterator`.
           </li>
           <li>
-            If the `value` property in the yielded result from the Symbol.AsyncIterator is undefined and the `done` property is set to `true`, set the <a href="#dom-thingdiscovery-done">done</a> property to `true` and reject |promise|.
+            If the `value` property in the yielded result from the `Symbol.AsyncIterator` is undefined and the `done` property is set to `true`, set the <a href="#dom-thingdiscovery-done">done</a> property to `true` and reject |promise|.
           </li>
           <li>
             Resolve |promise| with |td| and abort these steps.

--- a/index.html
+++ b/index.html
@@ -3913,14 +3913,14 @@
     <section>
       <h3>Discovery Examples</h3>
       <p>
-        The following example finds {{ThingDescription}} objects of <a>Thing</a>s that are exposed by local hardware, regardless how many instances of <a>WoT Runtime</a> it is running. Note that the discovery can end (become inactive) before the internal <a>discovery results</a> queue is emptied, so we need to continue reading {{ThingDescription}} objects until done. This is typical with local and directory type discoveries.
+        The following example finds {{ThingDescription}} objects of <a>Thing</a>s that are exposed by local hardware, regardless how many instances of <a>WoT Runtime</a> it is running
+        Using the `Symbol.AsyncIterator` provided by the Discovery object, we can iterate asynchronously over the results and perform operations with the obtained {{ThingDescription}} objects.
       </p>
       <pre class="example" title="Fetch the Thing Description of a Thing">
         let discovery = new ThingDiscovery({ method: "direct" });
-        do {
-          let td = await discovery.next();
+        for await (let td of discovery) {
           console.log("Found Thing Description for " + td.title);
-        } while (!discovery.done);
+        }
       </pre>
       <p>
         The next example finds {{ThingDescription}} objects of <a>Thing</a>s listed in a <a>Thing Directory</a> service. We set a timeout for safety.


### PR DESCRIPTION
This is an attempt to create Web IDL definitions based on the example in https://github.com/w3c/wot-scripting-api/issues/364#issuecomment-1137703749. This is still a work in progress and far from mergeable, but we might already be able to use for discussing the details of the new API.

The most important changes are the addition of the [async iterable](https://webidl.spec.whatwg.org/#idl-async-iterable) keywords and the removal of the `next()` method (which is now available on the inherited `Symbol.asyncIterator` field). Assuming that the discovery process should start right away, I also removed the `start()` method. However, if it is good practice to have such a method in a web API, then it could of course still be included. 

Furthermore, as both the `direct` and the `directory` methods need URLs in order to work, I made the `filter` and its `url` field required. This could be either reverted if other discovery mechanisms should be supported, or sub-interfaces for the these two methods could be introduced, where `url` is in fact a required field.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-scripting-api/pull/405.html" title="Last updated on Oct 10, 2022, 11:41 AM UTC (099e1e6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/405/e94e160...JKRhb:099e1e6.html" title="Last updated on Oct 10, 2022, 11:41 AM UTC (099e1e6)">Diff</a>