### PR TITLE
refactor: move allowed types out of the parenthesis to make it more official

### DIFF
--- a/index.html
+++ b/index.html
@@ -750,7 +750,7 @@
     <p>
       <dfn>DataSchemaValue</dfn> is an
       <a href="https://www.ecma-international.org/ecma-262/11.0/index.html#sec-ecmascript-data-types-and-values">ECMAScript value</a> that is accepted for <a>DataSchema</a> defined in [[WoT-TD]].
-	  The possible values are of type <a href="https://262.ecma-international.org/11.0/#sec-ecmascript-language-types-null-type">null</a>, <a href="https://262.ecma-international.org/11.0/#sec-ecmascript-language-types-boolean-type">boolean</a>, <a href="https://262.ecma-international.org/11.0/#sec-ecmascript-language-types-number-type">number</a>, <a href="https://262.ecma-international.org/11.0/#sec-ecmascript-language-types-string-type">string</a>, <a href="https://262.ecma-international.org/11.0/#sec-array-objects">array</a>, or <a href="https://262.ecma-international.org/11.0/#sec-object-type">object</a>.
+	  The possible values MUST be of type <a href="https://262.ecma-international.org/11.0/#sec-ecmascript-language-types-null-type">null</a>, <a href="https://262.ecma-international.org/11.0/#sec-ecmascript-language-types-boolean-type">boolean</a>, <a href="https://262.ecma-international.org/11.0/#sec-ecmascript-language-types-number-type">number</a>, <a href="https://262.ecma-international.org/11.0/#sec-ecmascript-language-types-string-type">string</a>, <a href="https://262.ecma-international.org/11.0/#sec-array-objects">array</a>, or <a href="https://262.ecma-international.org/11.0/#sec-object-type">object</a>.
     </p>
     <p>
       {{ReadableStream}} is meant to be used for <a>WoT Interactions</a> that

--- a/index.html
+++ b/index.html
@@ -749,8 +749,8 @@
     </p>
     <p>
       <dfn>DataSchemaValue</dfn> is an
-      <a href="https://www.ecma-international.org/ecma-262/11.0/index.html#sec-ecmascript-data-types-and-values">ECMAScript value</a> that is accepted for <a>DataSchema</a> defined in [[WoT-TD]]
-      (i.e. null, boolean, number, string, array, or object).
+      <a href="https://www.ecma-international.org/ecma-262/11.0/index.html#sec-ecmascript-data-types-and-values">ECMAScript value</a> that is accepted for <a>DataSchema</a> defined in [[WoT-TD]].
+	  The possible values are of type <code>null</code>, <code>boolean</code>, <code>number</code>, <code>string</code>, <code>array</code>, or <code>object</code>.
     </p>
     <p>
       {{ReadableStream}} is meant to be used for <a>WoT Interactions</a> that

--- a/index.html
+++ b/index.html
@@ -750,7 +750,7 @@
     <p>
       <dfn>DataSchemaValue</dfn> is an
       <a href="https://www.ecma-international.org/ecma-262/11.0/index.html#sec-ecmascript-data-types-and-values">ECMAScript value</a> that is accepted for <a>DataSchema</a> defined in [[WoT-TD]].
-	  The possible values are of type <code>null</code>, <code>boolean</code>, <code>number</code>, <code>string</code>, <code>array</code>, or <code>object</code>.
+	  The possible values are of type <a href="https://262.ecma-international.org/11.0/#sec-ecmascript-language-types-null-type">null</a>, <a href="https://262.ecma-international.org/11.0/#sec-ecmascript-language-types-boolean-type">boolean</a>, <a href="https://262.ecma-international.org/11.0/#sec-ecmascript-language-types-number-type">number</a>, <a href="https://262.ecma-international.org/11.0/#sec-ecmascript-language-types-string-type">string</a>, <a href="https://262.ecma-international.org/11.0/#sec-array-objects">array</a>, or <a href="https://262.ecma-international.org/11.0/#sec-object-type">object</a>.
     </p>
     <p>
       {{ReadableStream}} is meant to be used for <a>WoT Interactions</a> that


### PR DESCRIPTION
fixes https://github.com/w3c/wot-scripting-api/issues/403


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-scripting-api/pull/414.html" title="Last updated on Jul 18, 2022, 12:23 PM UTC (2f2d1ca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/414/cf3d575...danielpeintner:2f2d1ca.html" title="Last updated on Jul 18, 2022, 12:23 PM UTC (2f2d1ca)">Diff</a>