### PR TITLE
refactor: remove observeHandler from  emitPropertyChange() steps

### DIFF
--- a/index.html
+++ b/index.html
@@ -2848,15 +2848,15 @@
             If a <a>Property</a> with the name |name| is not found,
             reject |promise| with {{NotFoundError}} and abort these steps.
           </li>
+		  <!--
+			Do we need a dedicated emitPropertChange handler instead of using readHandler?
+			see https://github.com/w3c/wot-scripting-api/issues/407
+		  -->
           <li>
             Let |handler:function| be `null.`
           </li>
           <li>
-            If there is an [[\observeHandler]] <a>internal slot</a> on |property|, let |handler| be that.
-          </li>
-          <li>
-            Otherwise, if there is a [[\readHandler]] <a>internal slot</a>
-            associated with |name| on |property|, let |handler| be that.
+            If there is an [[\readHandler]] <a>internal slot</a> on |property|, let |handler| be that.
           </li>
           <li>
             If |handler| is `null`, abort these steps.


### PR DESCRIPTION
fixes https://github.com/w3c/wot-scripting-api/issues/407


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-scripting-api/pull/415.html" title="Last updated on Jul 11, 2022, 3:32 PM UTC (f9de18f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/415/cf3d575...danielpeintner:f9de18f.html" title="Last updated on Jul 11, 2022, 3:32 PM UTC (f9de18f)">Diff</a>