### PR TITLE
Fix internal slots

### DIFF
--- a/index.html
+++ b/index.html
@@ -1364,9 +1364,9 @@
     <section>
       <h3>The <dfn>getThingDescription()</dfn> method</h3>
       <p>
-        Returns the <a>internal slot</a> [[\td]] of the {{ConsumedThing}} object
+        Returns the {{ConsumedThing/[[td]]}} of the {{ConsumedThing}} object
         that represents the <a>Thing Description</a> of the {{ConsumedThing}}.
-        Applications may consult the <a>Thing</a> metadata stored in [[\td]] in
+        Applications may consult the <a>Thing</a> metadata stored in {{ConsumedThing/[[td]]}} in
         order to introspect its capabilities before interacting with it.
       </p>
     </section>
@@ -1390,7 +1390,7 @@
             {{SecurityError}} and abort these steps.
           </li>
           <li>
-            Let |interaction| be the value of [[\td]]'s |properties|'s
+            Let |interaction| be the value of {{ConsumedThing/[[td]]}}'s |properties|'s
             |propertyName|.
           </li>
           <li>
@@ -1450,7 +1450,7 @@
           </li>
           <li>
             If |option|'s |formIndex| is defined, let |form| be the
-            <a>Form</a> associated with |formIndex| in [[\td]]'s |forms| array, otherwise let |form| be a <a>Form</a> in [[\td]]'s |forms| array whose |op| is `readmultipleproperties`, selected by
+            <a>Form</a> associated with |formIndex| in {{ConsumedThing/[[td]]}}'s |forms| array, otherwise let |form| be a <a>Form</a> in {{ConsumedThing/[[td]]}}'s |forms| array whose |op| is `readmultipleproperties`, selected by
             the implementation.
           </li>
           <li>
@@ -1473,7 +1473,7 @@
                 Let |value| be the value of |result|'s |key|.
               </li>
               <li>
-                Let |schema| be the value of [[\td]]'s |properties|'s |key|.
+                Let |schema| be the value of {{ConsumedThing/[[td]]}}'s |properties|'s |key|.
               </li>
               <li>
                 Let |property| be the result of running
@@ -1509,7 +1509,7 @@
           </li>
           <li>
             If |option|'s |formIndex| is defined, let |form| be the
-            <a>Form</a> associated with |formIndex| in [[\td]]'s |forms| array, otherwise let |form| be a <a>Form</a> in [[\td]]'s |forms| array whose |op| is `readallproperties`, selected by
+            <a>Form</a> associated with |formIndex| in {{ConsumedThing/[[td]]}}'s |forms| array, otherwise let |form| be a <a>Form</a> in {{ConsumedThing/[[td]]}}'s |forms| array whose |op| is `readallproperties`, selected by
             the implementation.
           </li>
           <li>
@@ -1535,7 +1535,7 @@
                 Let |value| be the value of |result|'s |key|.
               </li>
               <li>
-                Let |schema| be the value of [[\td]]'s |properties|'s |key|.
+                Let |schema| be the value of {{ConsumedThing/[[td]]}}'s |properties|'s |key|.
               </li>
               <li>
                 Let |property| be the result of running
@@ -1566,7 +1566,7 @@
             If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
           </li>
           <li>
-            Let |interaction| be the value of [[\td]]'s |properties|'s
+            Let |interaction| be the value of {{ConsumedThing/[[td]]}}'s |properties|'s
             |propertyName|.
           </li>
           <li>
@@ -1631,8 +1631,8 @@
           </li>
           <li>
             If |option|'s |formIndex| is defined, let |form| be the
-            <a>Form</a> associated with |formIndex| in [[\td]]'s |forms| array,
-            otherwise let |form| be a <a>Form</a> in [[\td]]'s |forms|
+            <a>Form</a> associated with |formIndex| in {{ConsumedThing/[[td]]}}'s |forms| array,
+            otherwise let |form| be a <a>Form</a> in {{ConsumedThing/[[td]]}}'s |forms|
             array whose |op| is `writemultipleproperties`, selected by
             the implementation.
           </li>
@@ -1644,7 +1644,7 @@
             Let |propertyNames| be an array of |string| with as elements the keys of the |properties| object.
           </li>
           <li>
-            For each |name:string| in |propertyNames|, let |property| be the value of [[\td]]'s |properties|'s |name|.
+            For each |name:string| in |propertyNames|, let |property| be the value of {{ConsumedThing/[[td]]}}'s |properties|'s |name|.
             If |property| is `null` or `undefined` or is not `writeable` reject |promise| with {{NotSupportedError}}
             and abort these steps.
           </li>
@@ -1655,7 +1655,7 @@
           <li>
             Let |schemas:object| be an object and for each string |name:string|
             in |propertyNames| add a property with key |name| and let its value
-            be the value of [[\td]]'s |properties|'s |name|.
+            be the value of {{ConsumedThing/[[td]]}}'s |properties|'s |name|.
           </li>
           <li>
             For each key |key:string| in |properties|, take its value as |value|
@@ -1732,7 +1732,7 @@
                 Let |subscription|'s {{Subscription/[[name]]}} be the value of |propertyName|.
               </li>
               <li>
-                Let |subscription|'s {{Subscription/[[interaction]]}} be the value of [[\td]]'s
+                Let |subscription|'s {{Subscription/[[interaction]]}} be the value of {{ConsumedThing/[[td]]}}'s
                 |properties|'s |propertyName|.
               </li>
               <li>
@@ -1820,7 +1820,7 @@
             If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
           </li>
           <li>
-            Let |interaction| be the value of [[\td]]'s |actions|'s
+            Let |interaction| be the value of {{ConsumedThing/[[td]]}}'s |actions|'s
             |actionName|.
           </li>
           <li>
@@ -1906,7 +1906,7 @@
                 Let |subscription|'s {{Subscription/[[name]]}} be the value of |eventName|.
               </li>
               <li>
-                Let |subscription|'s {{Subscription/[[interaction]]}} be the value of [[\td]]'s
+                Let |subscription|'s {{Subscription/[[interaction]]}} be the value of {{ConsumedThing/[[td]]}}'s
                 |events|'s |eventName|.
               </li>
               <li>
@@ -2439,11 +2439,11 @@
          </tr>
         </thead>
         <tbody data-link-for="ExposedThing">
-         <tr>
-          <td><strong><em>[[\td]]</em></strong></td>
-          <td>`null`</td>
-          <td>The <a>Thing Description</a> of the <a>Thing</a>.</td>
-         </tr>
+          <tr>
+            <td><dfn>[[\td]]</dfn></td>
+            <td>`null`</td>
+            <td>The <a>Thing Description</a> of the {{ExposedThing}}.</td>
+          </tr>
         </tbody>
       </table>
     </section>
@@ -2477,7 +2477,7 @@
             Let |thing:ExposedThing| be a new {{ExposedThing}} object.
           </li>
           <li>
-            Set the <a>internal slot</a> [[\td]] of |thing| to |td|.
+            Set the {{ExposedThing/[[td]]}} of |thing| to |td|.
           </li>
           <li>
             Return |thing|.
@@ -2489,9 +2489,9 @@
     <section data-dfn-for="ExposedThing">
       <h3>The <dfn>getThingDescription()</dfn> method</h3>
       <p>
-        Returns the <a>internal slot</a> [[\td]] of the {{ExposedThing}} object
+        Returns the {{ExposedThing/[[td]]}} of the {{ExposedThing}} object
         that represents the <a>Thing Description</a> of the <a>Thing</a>.
-        Applications may consult the <a>Thing</a> metadata stored in [[\td]] in
+        Applications may consult the <a>Thing</a> metadata stored in {{ExposedThing/[[td]]}} in
         order to introspect its capabilities before interacting with it.
       </p>
     </section>
@@ -2526,7 +2526,7 @@
          The |handler| callback function should implement reading a <a>Property</a> and SHOULD be called by implementations when a request for reading a <a>Property</a> is received from the underlying platform.
       </p>
       <p>
-        There MUST be at most one handler for any given <a>Property</a>, so newly added handlers MUST replace the previous handlers. If no handler is initialized for any given <a>Property</a>, implementations SHOULD implement a default property read handler based on the <a>Thing Description</a> provided in the [[\td]] <a>internal slot</a>.
+        There MUST be at most one handler for any given <a>Property</a>, so newly added handlers MUST replace the previous handlers. If no handler is initialized for any given <a>Property</a>, implementations SHOULD implement a default property read handler based on the <a>Thing Description</a> provided in the {{ExposedThing/[[td]]}} <a>internal slot</a>.
       </p>
       <div>
         When the method is invoked given |name:string| and
@@ -2537,7 +2537,7 @@
             If invoking this method is not allowed for the current scripting context for security reasons, [= exception/throw =] a {{SecurityError}} and abort these steps.
           </li>
           <li>
-            Let |interaction| be the value of [[\td]]'s |properties|'s
+            Let |interaction| be the value of {{ExposedThing/[[td]]}}'s |properties|'s
             |name|.
           </li>
           <li>
@@ -2571,7 +2571,7 @@
             steps with |name:string| and |options:InteractionOptions|:
             <ol>
               <li>
-                Let |interaction| be the value of [[\td]]'s |properties|'s
+                Let |interaction| be the value of {{ExposedThing/[[td]]}}'s |properties|'s
                 |name|.
               </li>
               <li>
@@ -2702,7 +2702,7 @@
             If invoking this method is not allowed for the current scripting context for security reasons, [= exception/throw =] a {{SecurityError}} and abort these steps.
           </li>
           <li>
-            Let |interaction| be the value of [[\td]]'s |properties|'s
+            Let |interaction| be the value of {{ExposedThing/[[td]]}}'s |properties|'s
             |name|.
           </li>
           <li>
@@ -2732,7 +2732,7 @@
             according to the <a>Protocol Bindings</a> and abort these steps.
           </li>
           <li>
-            Let |property| be the value of [[\td]]'s |properties|'s |name|.
+            Let |property| be the value of {{ExposedThing/[[td]]}}'s |properties|'s |name|.
             If it does not exist, send back a {{NotFoundError}} in the
             reply and abort these steps.
           </li>
@@ -2775,7 +2775,7 @@
             {{SecurityError}} and abort these steps.
           </li>
           <li>
-            Let |interaction| be the value of [[\td]]'s |properties|'s
+            Let |interaction| be the value of {{ExposedThing/[[td]]}}'s |properties|'s
             |name|.
           </li>
           <li>
@@ -2805,7 +2805,7 @@
             according to the <a>Protocol Bindings</a> and abort these steps.
           </li>
           <li>
-            Let |property| be the value of [[\td]]'s |properties|'s |name|.
+            Let |property| be the value of {{ExposedThing/[[td]]}}'s |properties|'s |name|.
             If it does not exist, send back a {{NotFoundError}} in the
             reply and abort these steps.
           </li>
@@ -2842,7 +2842,7 @@
             If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
           </li>
           <li>
-            Let |property| be the value of [[\td]]'s |properties|'s |name|.
+            Let |property| be the value of {{ExposedThing/[[td]]}}'s |properties|'s |name|.
           </li>
           <li>
             If a <a>Property</a> with the name |name| is not found,
@@ -2936,7 +2936,7 @@
             If invoking this method is not allowed for the current scripting context for security reasons, [= exception/throw =] a {{SecurityError}} and abort these steps.
           </li>
           <li>
-            Let |interaction| be the value of [[\td]]'s |properties|'s
+            Let |interaction| be the value of {{ExposedThing/[[td]]}}'s |properties|'s
             |name|.
           </li>
           <li>
@@ -2968,7 +2968,7 @@
             according to the <a>Protocol Bindings</a> and abort these steps.
           </li>
           <li>
-            Let |interaction| be the value of [[\td]]'s |properties|'s
+            Let |interaction| be the value of {{ExposedThing/[[td]]}}'s |properties|'s
             |name|.
           </li>
           <li>
@@ -3063,7 +3063,7 @@
             If invoking this method is not allowed for the current scripting context for security reasons, [= exception/throw =] a {{SecurityError}} and abort these steps.
           </li>
           <li>
-            Let |interaction| be the value of [[\td]]'s |actions|'s
+            Let |interaction| be the value of {{ExposedThing/[[td]]}}'s |actions|'s
             |name|.
           </li>
           <li>
@@ -3092,7 +3092,7 @@
             according to the <a>Protocol Bindings</a> and abort these steps.
           </li>
           <li>
-            Let |interaction| be the value of [[\td]]'s |properties|'s
+            Let |interaction| be the value of {{ExposedThing/[[td]]}}'s |properties|'s
             |name|.
           </li>
           <li>
@@ -3175,7 +3175,7 @@
             If invoking this method is not allowed for the current scripting context for security reasons, [= exception/throw =] a {{SecurityError}} and abort these steps.
           </li>
           <li>
-            Let |interaction| be the value of [[\td]]'s |events|'s
+            Let |interaction| be the value of {{ExposedThing/[[td]]}}'s |events|'s
             |name|.
           </li>
           <li>
@@ -3208,7 +3208,7 @@
             according to the <a>Protocol Bindings</a> and abort these steps.
           </li>
           <li>
-            Let |interaction| be the value of [[\td]]'s |events|'s
+            Let |interaction| be the value of {{ExposedThing/[[td]]}}'s |events|'s
             |name|.
           </li>
           <li>
@@ -3261,7 +3261,7 @@
             If invoking this method is not allowed for the current scripting context for security reasons, [= exception/throw =] a {{SecurityError}} and abort these steps.
           </li>
           <li>
-            Let |interaction| be the value of [[\td]]'s |events|'s
+            Let |interaction| be the value of {{ExposedThing/[[td]]}}'s |events|'s
             |name|.
           </li>
           <li>
@@ -3294,7 +3294,7 @@
             according to the <a>Protocol Bindings</a> and abort these steps.
           </li>
           <li>
-            Let |interaction| be the value of [[\td]]'s |events|'s
+            Let |interaction| be the value of {{ExposedThing/[[td]]}}'s |events|'s
             |name|.
           </li>
           <li>
@@ -3345,7 +3345,7 @@
             If invoking this method is not allowed for the current scripting context for security reasons, [= exception/throw =] a {{SecurityError}} and abort these steps.
           </li>
           <li>
-            Let |interaction| be the value of [[\td]]'s |events|'s
+            Let |interaction| be the value of {{ExposedThing/[[td]]}}'s |events|'s
             |name|.
           </li>
           <li>
@@ -3371,7 +3371,7 @@
         following steps:
         <ol>
           <li>
-            Let |interaction| be the value of [[\td]]'s |events|'s
+            Let |interaction| be the value of {{ExposedThing/[[td]]}}'s |events|'s
             |name|.
           </li>
           <li>
@@ -3431,7 +3431,7 @@
             If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
           </li>
           <li>
-            Let |interaction| be the value of [[\td]]'s |events|'s |name|.
+            Let |interaction| be the value of {{ExposedThing/[[td]]}}'s |events|'s |name|.
           </li>
           <li>
             If an <a>Event</a> with the name |name| is not found,
@@ -3460,25 +3460,25 @@
             If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
           </li>
           <li>
-            Run the <a>expand a TD</a> steps on the <a>internal slot</a> [[\td]].
+            Run the <a>expand a TD</a> steps on the {{ExposedThing/[[td]]}}.
           </li>
           <li>
-            Run the <a>validate a TD</a> on [[\td]]. If that fails,
+            Run the <a>validate a TD</a> on {{ExposedThing/[[td]]}}. If that fails,
             reject |promise| with a {{TypeError}} and abort these steps.
           </li>
           <li>
-            For each <a>Property</a> definition in [[\td]]'s |properties|,
+            For each <a>Property</a> definition in {{ExposedThing/[[td]]}}'s |properties|,
             initialize an |<dfn>internal observer list</dfn>| <a>internal slot</a>
             in order to store observe request data needed to notify the observers on value changes.
           </li>
           <li>
-            For each <a>Event</a> definition is [[\td]]'s |events|,
+            For each <a>Event</a> definition is {{ExposedThing/[[td]]}}'s |events|,
             initialize an |<dfn>internal listener list</dfn>| <a>internal slot</a>
             in order to store subscription request data needed to notify the
             <a>Event</a> listeners.
           </li>
           <li>
-            Set up the <a>WoT Interactions</a> based on introspecting [[\td]]
+            Set up the <a>WoT Interactions</a> based on introspecting {{ExposedThing/[[td]]}}
             as explained in [[!WOT-TD]] and [[!WOT-PROTOCOL-BINDINGS]].
             Make a request to the underlying platform to initialize the
             <a>Protocol Bindings</a> and then start serving external requests

--- a/index.html
+++ b/index.html
@@ -2831,7 +2831,7 @@
             reply and abort these steps.
           </li>
           <li>
-            If there is a user provided {{Function}} in {{ExposedThing/[[observeHandlers]]}} <a>internal slot</a>
+            If there is a user provided {{Function}} in {{ExposedThing/[[unobserveHandlers]]}} <a>internal slot</a>
             for |interaction|, invoke that with |options|, send back a
             reply following the <a>Protocol Bindings</a> and abort these steps.
           </li>

--- a/index.html
+++ b/index.html
@@ -2441,6 +2441,31 @@
             <td>`null`</td>
             <td>The <a>Thing Description</a> of the {{ExposedThing}}.</td>
           </tr>
+          <tr>
+            <td><dfn>[[\readHandlers]]</dfn></td>
+            <td>`{}`</td>
+            <td>A {{Map}} with property names as keys and {{PropertyReadHandler}}s as values</td>
+          </tr>
+          <tr>
+            <td><dfn>[[\writeHandlers]]</dfn></td>
+            <td>`{}`</td>
+            <td>A {{Map}} with property names as keys and {{PropertyWriteHandler}}s as values</td>
+          </tr>
+          <tr>
+            <td><dfn>[[\observeHandlers]]</dfn></td>
+            <td>`{}`</td>
+            <td>A {{Map}} with property names as keys and {{PropertyReadHandler}}s as values</td>
+          </tr>
+          <tr>
+            <td><dfn>[[\unobserveHandlers]]</dfn></td>
+            <td>`{}`</td>
+            <td>A {{Map}} with property names as keys and {{Function}}s as values</td>
+          </tr>
+          <tr>
+            <td><dfn>[[\actionHandlers]]</dfn></td>
+            <td>`{}`</td>
+            <td>A {{Map}} with action names as keys and {{ActionHandler}}s as values</td>
+          </tr>
         </tbody>
       </table>
     </section>
@@ -2542,8 +2567,7 @@
             [= exception/throw =] {{NotFoundError}} and abort these steps.
           </li>
           <li>
-            Add the <a>internal slot</a> [[\readHandler]] to |interaction| and
-            set it to |handler|.
+            Set the pair (|interaction|,|handler|) in {{ExposedThing/[[readHandlers]]}} <a>internal slot</a>.
           </li>
         </ol>
       </div>
@@ -2578,8 +2602,8 @@
                 Let |handler:function| be `null`.
               </li>
               <li>
-                If there is a user provided <a>internal slot</a> [[\readHandler]]
-                on |interaction|, let |handler| be that.
+                If there is a user provided {{PropertyReadHandler}} in {{ExposedThing/[[readHandlers]]}} <a>internal slot</a> 
+                for |interaction|, let |handler| be that.
               </li>
               <li>
                 Otherwise, if there is a default read handler provided by the implementation, let |handler| be that.
@@ -2707,8 +2731,8 @@
             [= exception/throw =] {{NotFoundError}} and abort these steps.
           </li>
           <li>
-            Set the <a>internal slot</a> [[\observeHandler]] on |interaction|
-            to |handler|.
+            Set the pair (|interaction|,|handler|) in {{ExposedThing/[[observeHandlers]]}} 
+            <a>internal slot</a>.
           </li>
         </ol>
       </div>
@@ -2780,8 +2804,8 @@
             [= exception/throw =] {{NotFoundError}} and abort these steps.
           </li>
           <li>
-            Set the <a>internal slot</a> [[\unobserveHandler]] on |interaction|
-            to |handler|.
+            Set the pair (|interaction|,|handler|) in {{ExposedThing/[[unobserveHandlers]]}} 
+            <a>internal slot</a>.
           </li>
         </ol>
       </div>
@@ -2807,8 +2831,8 @@
             reply and abort these steps.
           </li>
           <li>
-            If there is an [[\unobserveHandler]] of type {{Function}} defined
-            for |name| on |property|, invoke that with |options|, send back a
+            If there is a user provided {{Function}} in {{ExposedThing/[[observeHandlers]]}} <a>internal slot</a>
+            for |interaction|, invoke that with |options|, send back a
             reply following the <a>Protocol Bindings</a> and abort these steps.
           </li>
           <li>
@@ -2853,7 +2877,8 @@
             Let |handler:function| be `null.`
           </li>
           <li>
-            If there is an [[\readHandler]] <a>internal slot</a> on |property|, let |handler| be that.
+            If there is a user provided {{PropertyReadHandler}} in {{ExposedThing/[[readHandlers]]}}
+            <a>internal slot</a> for |interaction|, let |handler| be that.
           </li>
           <li>
             If |handler| is `null`, abort these steps.
@@ -2941,8 +2966,8 @@
             [= exception/throw =] {{NotFoundError}} and abort these steps.
           </li>
           <li>
-            Set the <a>internal slot</a> [[\writeHandler]] on |interaction|
-            to |handler|.
+            Set the pair (|interaction|,|handler|) in {{ExposedThing/[[writeHandlers]]}} 
+            <a>internal slot</a>.
           </li>
         </ol>
       </div>
@@ -2975,8 +3000,8 @@
             Let |handler:function| be `null`.
           </li>
           <li>
-            If there is a user provided <a>internal slot</a> [[\writeHandler]]
-            on |interaction|, let |handler| be that.
+            If there is a user provided {{PropertyWriteHandler}} in {{ExposedThing/[[writeHandlers]]}}
+            <a>internal slot</a> for |interaction|, let |handler| be that.
           </li>
           <li>
             Otherwise, if there is a default write handler provided by the implementation, let |handler| be that.
@@ -3068,8 +3093,8 @@
             [= exception/throw =] a {{NotFoundError}} and abort these steps.
           </li>
           <li>
-            Set the <a>internal slot</a> [[\actionHandler]] on |interaction|
-            to |action|.
+            Set the pair (|interaction|,|handler|) in {{ExposedThing/[[actionHandlers]]}}
+            <a>internal slot</a>.
           </li>
         </ol>
       </div>
@@ -3099,8 +3124,8 @@
             Let |handler:function| be `null`.
           </li>
           <li>
-            If there is a user provided <a>internal slot</a> [[\actionHandler]]
-            on |interaction|, let |handler| be its value.
+            If there is a user provided {{ActionHandler}} in {{ExposedThing/[[actionHandlers]]}}
+            <a>internal slot</a> for |interaction|, let |handler| be that.
           </li>
           <li>
             If |handler| is `null`, return a {{NotSupportedError}} with the reply


### PR DESCRIPTION
I noticed that we are not correctly referencing the internal slots we defined. Moreover, in `ExposedThing` we are using internal slots in the "old way". I'd like to fix this issue too.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/relu91/wot-scripting-api/pull/424.html" title="Last updated on Dec 19, 2022, 6:28 PM UTC (b76dcee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/424/6fcfdb6...relu91:b76dcee.html" title="Last updated on Dec 19, 2022, 6:28 PM UTC (b76dcee)">Diff</a>