### PR TITLE
refactor: fix/remove emphasised empty

### DIFF
--- a/index.html
+++ b/index.html
@@ -3325,7 +3325,7 @@
               </li>
               <li>
                   If |data| is `undefined`, assume that the notification |response| 
-                  will contain an <emph>empty</emph> data payload as specified by <a>Protocol Bindings</a>. 
+                  will contain an empty data payload as specified by <a>Protocol Bindings</a>. 
               </li>
               <li>
                 If the underlying protocol stack permits conveying event errors and


### PR DESCRIPTION
PR https://github.com/w3c/wot-scripting-api/pull/423 introduced the emphasis for _empty._ I suggest to remove it all together. 

1. `emph` is for LaTeX (my fault), in HTML it should be `<em>`
2. I quickly skimmed the current document and we use empty without emphasizing


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/pull/432.html" title="Last updated on Sep 26, 2022, 12:16 PM UTC (7b8f4ee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/432/c7c2cf2...7b8f4ee.html" title="Last updated on Sep 26, 2022, 12:16 PM UTC (7b8f4ee)">Diff</a>