### PR TITLE
fix: remove mentioning of internal discovery results

### DIFF
--- a/index.html
+++ b/index.html
@@ -3632,7 +3632,7 @@
       The <dfn>active</dfn> property is `true` when the discovery is actively ongoing on protocol level (i.e. new <a>TD</a>s may still arrive) and `false` otherwise.
     </p>
     <p>
-      The <dfn>done</dfn> property is `true` if the discovery has been completed with no more results to report and <a>discovery results</a> is also empty.
+      The <dfn>done</dfn> property is `true` if the discovery has been completed with no more results to report.
     </p>
     <p>
       The <dfn>error</dfn> property represents the last error that occurred during the discovery process. Typically used for critical errors that stop discovery.


### PR DESCRIPTION
This PR provides a partial resolution of #437. I think we can safely remove the reference of the internal slot, resolving the ReSpec error, but as @zolkis mentioned in the issue, we need to follow up with further `Symbol.asyncIterator`-related adjustments.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-scripting-api/pull/438.html" title="Last updated on Oct 24, 2022, 10:42 AM UTC (e8f2d8d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/438/8f835c3...JKRhb:e8f2d8d.html" title="Last updated on Oct 24, 2022, 10:42 AM UTC (e8f2d8d)">Diff</a>