### PR TITLE
Align the discovery API with the Discovery spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,7 +212,7 @@
           then instantiating a software stack that implements the <a>WoT Interface</a> specified by the <a>TD</a> in order to serve requests for accessing the exposed <a>Properties</a>, <a>Actions</a> and <a>Events</a>,
         </li>
         <li>
-           then eventually publishing the <a>Thing Description</a> (for instance to a <a>Thing Directory</a> directory for easier discovery).
+           then eventually publishing the <a>Thing Description</a> (for instance to a <a>TD Directory</a> directory for easier discovery).
         </li>
       </ul>
       This specification describes how to expose and consume <a>Thing</a>s by a script. Also, it defines a generic API for <a>Thing</a> discovery.
@@ -308,7 +308,7 @@
       <li>Discover <a>Thing</a>s running in the local <a>WoT Runtime</a>.</li>
       <li>Discover nearby <a>Thing</a>s, for instance connected by NFC or Bluetooth,
         or within a <a href="https://en.wikipedia.org/wiki/Geo-fence">geo-fence</a>.</li>
-      <li>Discover <a>Thing</a>s by sending a discovery request to a given <a>Thing Directory</a>.</li>
+      <li>Discover <a>Thing</a>s by sending a discovery request to a given <a>TD Directory</a>.</li>
       <li>Discover <a>Thing</a>s filtered by filters defined on <a>Thing Description</a>s</li>
       <li>Discover <a>Thing</a>s filtered by semantic queries.</li>
       <li>Stop or suppress an ongoing discovery process.</li>
@@ -751,7 +751,7 @@
       };
     </pre>
     <div>
-      Belongs to the <a>WoT Discovery</a> conformance class. Starts the discovery process that given a <a>Thing Directory</a> URL, will provide {{ThingDescription}} objects for <a>Thing Description</a>s that match an optional |filter:ThingFilter| argument of type {{ThingFilter}}. The method MUST run the following steps:
+      Belongs to the <a>WoT Discovery</a> conformance class. Starts the discovery process that given a <a>TD Directory</a> URL, will provide {{ThingDescription}} objects for <a>Thing Description</a>s that match an optional |filter:ThingFilter| argument of type {{ThingFilter}}. The method MUST run the following steps:
       <ol>
         <li>
           Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
@@ -3736,7 +3736,7 @@
       <tr>
         <td>[[\url]]</td>
         <td>`undefined`</td>
-        <td>A {{URL}} representing the <a>Thing Directory</a> in a discovery.</td>
+        <td>A {{URL}} representing the <a>TD Directory</a> in a discovery.</td>
       </tr>
       </tbody>
     </table>
@@ -3798,12 +3798,12 @@
         <a>ThingFilter</a>, until it is standardized in the WoT Discovery
         task force. It represented a query string accepted by the implementation,
         for instance a SPARQL or JSON query. Support was to be implemented locally
-        in the <a>WoT Runtime</a> or remotely as a service in a <a>Thing Directory</a>.
+        in the <a>WoT Runtime</a> or remotely as a service in a <a>TD Directory</a>.
       </p>
       <p class="ednote">
         The |url:USVString| property was removed. It used to represent the target
         entity serving the discovery request, for instance the URL of a
-        <a>Thing Directory</a>, or the URL of a directly targeted <a>Thing</a>,
+        <a>TD Directory</a>, or the URL of a directly targeted <a>Thing</a>,
         but these are implemented by dedicated methods now.
       </p>
     </section>
@@ -3978,7 +3978,7 @@
         console.log("Found Thing Description for " + td.title);
       </pre>
       <p>
-        The next example finds {{ThingDescription}} objects of <a>Thing</a>s listed in a <a>Thing Directory</a> service. We set a timeout for safety.
+        The next example finds {{ThingDescription}} objects of <a>Thing</a>s listed in a <a>TD Directory</a> service. We set a timeout for safety.
       </p>
       <pre class="example" title="Discover Things via directory">
         let discovery = WOT.exploreDirectory("http://directory.wotservice.org");

--- a/index.html
+++ b/index.html
@@ -378,7 +378,7 @@
   
   <section> <h2>Terminology and conventions</h2>
     <p>
-      The generic WoT terminology is defined in [[!WOT-ARCHITECTURE]]: <dfn data-lt="Things">Thing</dfn>, <dfn data-lt="Thing Descriptions">Thing Description</dfn> (in short <dfn>TD</dfn>), <dfn>Partial TD</dfn>, <dfn>Web of Things</dfn> (in short <b><i>WoT</i></b>),  <dfn>WoT Interface</dfn>, <dfn>Protocol Bindings</dfn>, <dfn>WoT Runtime</dfn>, <dfn data-lt="consume|consume a TD|consuming a TD">Consuming a Thing Description</dfn>, <dfn>Thing Directory</dfn>, <dfn data-lt="Properties">Property</dfn>, <dfn data-lt="Actions">Action</dfn>, <dfn data-lt="Events|WoT-Event">Event</dfn>,
+      The generic WoT terminology is defined in [[!WOT-ARCHITECTURE]]: <dfn data-lt="Things">Thing</dfn>, <dfn data-lt="Thing Descriptions">Thing Description</dfn> (in short <dfn>TD</dfn>), <dfn>Partial TD</dfn>, <dfn>Web of Things</dfn> (in short <b><i>WoT</i></b>),  <dfn>WoT Interface</dfn>, <dfn>Protocol Bindings</dfn>, <dfn>WoT Runtime</dfn>, <dfn data-lt="consume|consume a TD|consuming a TD">Consuming a Thing Description</dfn>, <dfn>TD Directory</dfn>, <dfn data-lt="Properties">Property</dfn>, <dfn data-lt="Actions">Action</dfn>, <dfn data-lt="Events|WoT-Event">Event</dfn>,
       <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#dataschema">
         <dfn>DataSchema</dfn></a>, <a href="https://www.w3.org/TR/2020/WD-wot-thing-description11-20201124/#form"><dfn data-lt="Forms">Form</dfn></a>,
         <a href="https://w3c.github.io/wot-thing-description/#securityscheme"><dfn>SecurityScheme</dfn></a>, <a href="https://w3c.github.io/wot-thing-description/#nosecurityscheme"><dfn>NoSecurityScheme</dfn></a> etc.

--- a/index.html
+++ b/index.html
@@ -3981,7 +3981,7 @@
         The next example finds {{ThingDescription}} objects of <a>Thing</a>s listed in a <a>TD Directory</a> service. We set a timeout for safety.
       </p>
       <pre class="example" title="Discover Things via directory">
-        let discovery = WOT.exploreDirectory("http://directory.wotservice.org");
+        let discovery = await WOT.exploreDirectory("http://directory.wotservice.org");
         setTimeout( () => {
             discovery.stop();
             console.log("Discovery stopped after timeout.");
@@ -4001,7 +4001,7 @@
         to the WOT runtime, including local Things, if any is available.
       </p>
       <pre class="example" title="Discover Things in a network">
-        let discovery = WOT.discover();
+        let discovery = await WOT.discover();
         setTimeout( () => {
             discovery.stop();
             console.log("Stopped open-ended discovery");

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
             ]
           },
         ],
-        xref: ["web-platform", "streams", "wot-architecture", "wot-thing-description", "wot-binding-templates", "html", "infra", "ecmascript"],
+        xref: ["web-platform", "streams", "wot-architecture", "wot-thing-description", "wot-binding-templates", "html", "infra", "url", "ecmascript"],
         localBiblio: {
           "WOT-ARCHITECTURE" : {
             href:"https://www.w3.org/TR/2020/WD-wot-architecture11-20201124/",
@@ -351,7 +351,11 @@
       </dt>
       <dd>
         <p>
-          Implementations of this conformance class MUST implement the <code><a>ThingDiscovery</a></code> interface and the <code>discover()</code> method on the <a>WoT API object</a>.
+          Implementations of this conformance class MUST implement the
+          <code><a>ThingDiscoveryProcess</a></code> interface, the
+          <code>discover()</code> method, the <code>exploreDirectory()</code> method,
+          and the <code>requestThingDescription()</code> method on the
+          <a>WoT API object</a>.
         </p>
       </dd>
     </dl>
@@ -702,27 +706,120 @@
   <section> <h3>The <dfn>discover()</dfn> method</h3>
     <pre class="idl">
       partial namespace WOT {
-        ThingDiscovery discover(optional ThingFilter filter = null);
+        Promise&lt;ThingDiscoveryProcess&gt; discover(optional ThingFilter filter = null);
       };
     </pre>
     <div>
       Belongs to the <a>WoT Discovery</a> conformance class. Starts the discovery process that will provide {{ThingDescription}} objects for <a>Thing Description</a>s that match an optional |filter:ThingFilter| argument of type {{ThingFilter}}. The method MUST run the following steps:
       <ol>
         <li>
-          If invoking this method is not allowed for the current scripting context for security reasons, [= exception/throw =] a {{"SecurityError"}} and abort these steps.
+          Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
         </li>
         <li>
-          Construct a <a>ThingDiscovery</a> object |discovery:ThingDiscovery| with |filter|.
+          If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
         </li>
         <li>
-          Invoke the <a href="#the-start-method">discovery.start()</a> method.
+          If discovery is not supported by the implementation, reject |promise|
+          with {{NotSupportedError}} and abort these steps.
         </li>
         <li>
-          Return |discovery|.
+          Let |discovery:ThingDiscoveryProcess| be a new {{ThingDiscoveryProcess}} object.
+        </li>
+        <li>
+          Set |discovery|'s [[\filter]] <a>internal slot</a> to |filter:ThingFilter| or
+          `undefined`.
+        </li>
+        <li>
+          Set |discovery|'s [[\url]] <a>internal slot</a> to `undefined`.
+        </li>
+        <li>
+          Invoke the <a>generic discovery</a>
+          algorithm given |discovery:ThingDiscoveryProcess| and <code>`"generic"`</code>.
+        </li>
+        <li>
+          Resolve |promise| with |discovery|.
         </li>
       </ol>
     </div>
   </section>
+
+  <section> <h3>The <dfn>exploreDirectory()</dfn> method</h3>
+    <pre class="idl">
+      partial namespace WOT {
+        Promise&lt;ThingDiscoveryProcess&gt; exploreDirectory(USVString url,
+            optional ThingFilter filter = null);
+      };
+    </pre>
+    <div>
+      Belongs to the <a>WoT Discovery</a> conformance class. Starts the discovery process that given a <a>Thing Directory</a> URL, will provide {{ThingDescription}} objects for <a>Thing Description</a>s that match an optional |filter:ThingFilter| argument of type {{ThingFilter}}. The method MUST run the following steps:
+      <ol>
+        <li>
+          Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
+        </li>
+        <li>
+          If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
+        </li>
+        <li>
+          If directory discovery is not supported by the implementation, reject |promise|
+          with {{NotSupportedError}} and abort these steps.
+        </li>
+        <li>
+          Let |discovery:ThingDiscoveryProcess| be a new {{ThingDiscoveryProcess}} object.
+        </li>
+        <li>
+          Set |discovery|'s [[\url]] <a>internal slot</a> to |url:USVString|.
+        </li>
+        <li>
+          Set |discovery|'s [[\filter]] <a>internal slot</a> to |filter:ThingFilter|
+          or `undefined`.
+        </li>
+        <li>
+          Invoke the <a href="#the-generic-discovery-algorithm">generic discovery</a>
+          algorithm given |discovery:ThingDiscoveryProcess| and <code>`"directory"`</code>.
+        </li>
+        <li>
+          Resolve |promise| with |discovery|.
+        </li>
+      </ol>
+    </div>
+  </section>
+
+  <section> <h3>The <dfn>requestThingDescription()</dfn> method</h3>
+    <pre class="idl">
+      partial namespace WOT {
+        Promise&lt;ThingDescription&gt; requestThingDescription(USVString url);
+      };
+    </pre>
+    <div>
+      Belongs to the <a>WoT Discovery</a> conformance class.
+      Requests a <a>Thing Description</a> from the given URL.
+      The method MUST run the following steps:
+      <ol>
+        <li>
+          Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
+        </li>
+        <li>
+          If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
+        </li>
+        <li>
+          If fetching a <a>Thing Description</a> is not supported by the
+          implementation, reject |promise| with {{NotSupportedError}} and
+          abort these steps.
+        </li>
+        <li>
+          Let |td:ThingDescription| be the result of invoking the underlying
+          platform to retrieve the <a>Thing Description</a> using the
+            <a>Protocol Binding</a> specified by |url|.
+          If retrieving |td| fails, reject |promise| with {{NotFoundError}} and
+          abort these steps.
+        </li>
+        <li>
+          Resolve |promise| with |td|.
+        </li>
+      </ol>
+    </div>
+  </section>
+
   </section> <!-- WoT -->
 
   <section data-cite="webidl"> <h2>Handling interaction data</h2>
@@ -3600,94 +3697,86 @@
     </section> <!-- ExposedThing Examples -->
   </section> <!-- ExposedThing -->
 
-  <section data-cite="webidl" data-dfn-for="ThingDiscovery">
-    <h2>The <dfn>ThingDiscovery</dfn> interface</h2>
+  <section data-cite="webidl" data-dfn-for="ThingDiscoveryProcess">
+    <h2>The <dfn>ThingDiscoveryProcess</dfn> interface</h2>
     <p>
       Discovery is a distributed application that requires provisioning and support from participating network nodes (clients, servers, directory services). This API models the client side of typical discovery schemes supported by various IoT deployments.
     </p>
     <p>
-      The {{ThingDiscovery}} object is constructed given a filter and provides the properties and methods controlling the discovery process.
+      The {{ThingDiscoveryProcess}} object provides the properties and methods
+      controlling the discovery process and returning the results.
     </p>
     <pre class="idl">
       [SecureContext, Exposed=(Window,Worker)]
-      interface ThingDiscovery {
+      interface ThingDiscoveryProcess {
         constructor(optional ThingFilter filter = null);
-        readonly attribute ThingFilter? filter;
-        readonly attribute boolean active;
         readonly attribute boolean done;
         readonly attribute Error? error;
-        undefined start();
-        Promise&lt;ThingDescription&gt; next();
         undefined stop();
         async iterable&lt;ThingDescription&gt;;
       };
     </pre>
-    <p class="ednote">
-      The {{ThingDiscovery}} interface has a <code>next()</code> method and a <code>done</code> property, but it is not an <a href="https://tc39.es/proposal-async-iteration/">Iterable</a>. Look into <a href="https://github.com/w3c/wot-scripting-api/issues/177">Issue 177</a> for rationale.
-    </p>
     <p>
-      The <dfn>filter</dfn> property represents the discovery filter of type <a>ThingFilter</a> specified for the discovery.
+      The {{ThingDiscoveryProcess}} object has the following <a>internal slot</a>s.
     </p>
+    <table class="simple">
+      <thead>
+       <tr>
+        <th>Internal Slot</th>
+        <th>Initial value</th>
+        <th>Description (<em>non-normative</em>)</th>
+       </tr>
+      </thead>
+      <tbody data-link-for="ThingDiscoveryProcess">
+       <tr>
+        <td>[[\filter]]</td>
+        <td>`undefined`</td>
+        <td>The {{ThingFilter}} object used in discovery.</td>
+       </tr>
+      <tr>
+        <td>[[\url]]</td>
+        <td>`undefined`</td>
+        <td>A {{URL}} representing the <a>Thing Directory</a> in a discovery.</td>
+      </tr>
+      </tbody>
+    </table>
     <p>
-      The <dfn>active</dfn> property is `true` when the discovery is actively ongoing on protocol level (i.e. new <a>TD</a>s may still arrive) and `false` otherwise.
-    </p>
-    <p>
-      The <dfn>done</dfn> property is `true` if the discovery has been completed with no more results to report and <a>discovery results</a> is also empty.
+      The <dfn>done</dfn> property is `true` if the discovery has been stopped
+      or completed with no more results to report.
     </p>
     <p>
       The <dfn>error</dfn> property represents the last error that occurred during the discovery process. Typically used for critical errors that stop discovery.
     </p>
     <p>
-      <!-- TODO: Mention AsyncIterator/AsyncIterable? -->
+      The {{ThingDiscoveryProcess}} object implements the
+      <a href="https://tc39.es/ecma262/#sec-symbol.asynciterator">async iterator</a>
+      concept.
     </p>
 
-    <section><h3>Constructing {{ThingDiscovery}}</h3>
+    <section><h3>Constructing {{ThingDiscoveryProcess}}</h3>
       <div>
-        To create {{ThingDiscovery}} with a |filter:ThingFilter| or type {{ThingFilter}}, run the following steps:
+        To create {{ThingDiscoveryProcess}} with a |filter:ThingFilter|, run the following steps:
         <ol>
           <li>
             If |filter| is not an object or `null`, [= exception/throw =] a {{TypeError}} and abort these steps.
           </li>
           <li>
-            Let |discovery:ThingDiscovery| be a new {{ThingDiscovery}} object.
+            Let |discovery:ThingDiscoveryProcess| be a new {{ThingDiscoveryProcess}} object.
           </li>
           <li>
-            Set the <a href="#dom-thingdiscovery-filter">filter</a> property to |filter|.
+            Set the [[\filter]] <a>internal slot</a> to |filter|.
           </li>
           <li>
-            Set the <a href="#dom-thingdiscovery-active">active</a> and <a href="#dom-thingdiscovery-done">done</a> properties to `false`. Set the <a href="#dom-thingdiscovery-error">error</a> property to `null`.
+            Set the {{ThingDiscoveryProcess/done}} property to `false`.
+          </li>
+          <li>
+            Set the {{ThingDiscoveryProcess/error}} property to `null`.
           </li>
           <li>
             Return |discovery|.
           </li>
         </ol>
       </div>
-      <p>
-        The <a href="#the-start-method">start()</a> method sets <a href="#dom-thingdiscovery-active">active</a> to `true`. The <a href="#the-stop-method">stop()</a> method sets the <a href="#dom-thingdiscovery-active">active</a> property to |false|, but <a href="#dom-thingdiscovery-done">done</a> may be still `false` if there are {{ThingDescription}} objects which can be yielded by the {{Symbol/asyncIterator}}.
-      </p>
-      <p>
-         During successive calls of <a href="#the-next-method">next()</a>, the <a href="#dom-thingdiscovery-active">active</a> property may be `true` or `false`, but the <a href="#dom-thingdiscovery-done">done</a> property is set to `false` by <a href="#the-next-method">next()</a> only when both the <a href="#dom-thingdiscovery-active">active</a> property is `false` and the `done` property in the object yielded by the {{Symbol/asyncIterator}} is set to `true`.
-      </p>
-    </section>
-
-    <section data-dfn-for="DiscoveryMethod">
-      <h3>The <dfn>DiscoveryMethod</dfn> enumeration</h3>
-      <pre class="idl">
-        typedef DOMString DiscoveryMethod;
-      </pre>
-      <p>
-        Represents the discovery type to be used:
-      </p>
-      <ul>
-        <li>
-          "<dfn>direct</dfn>" for fetching the <a>Thing Description</a> of a
-          <a>Thing</a> specified by <a>ThingFilter</a>'s `url`.
-        </li>
-        <li>
-          "<dfn>directory</dfn>" for discovery based on a service provided by a
-          <a>Thing Directory</a> specified by <a>ThingFilter</a>'s `url`.
-        </li>
-      </ul>
     </section>
 
     <section data-dfn-for="ThingFilter">
@@ -3697,120 +3786,148 @@
       </p>
       <pre class="idl">
         dictionary ThingFilter {
-          DiscoveryMethod method = "directory";
-          USVString? url;
           object? fragment;
           <!-- DOMString? query; -->
         };
       </pre>
-      <p class = "ednote">
-        The `DOMString query` property was temporarily removed from
-        <a>ThingFilter</a>, until it is standardized in the WoT Discovery
-        task force.
-      </p>
-      <p>
-        The <dfn>method</dfn> property represents the discovery type that should be used in the discovery process. The possible values are defined by the <a href="#the-discoverymethod-enumeration">DiscoveryMethod</a> enumeration.
-      </p>
-      <p>
-        The <dfn>url</dfn> property represents the URL of the target entity serving the discovery request, for instance the URL of a <a>Thing Directory</a> (if <a href="#dom-thingfilter-method">method</a> is {{DiscoveryMethod/[["directory"]]}}),
-        or the URL of a directly targeted <a>Thing</a> (if
-        <a href="#dom-thingfilter-method">method</a> is {{DiscoveryMethod/[["direct"]]}})
-      </p>
       <p>
         The <dfn>fragment</dfn> property represents a template object used for matching property by property against discovered <a>Thing</a>s.
       </p>
-      <!--p>
-        The <dfn>query</dfn> property represents a query string accepted by the implementation, for instance a SPARQL or JSON query. Support may be implemented locally in the <a>WoT Runtime</a> or remotely as a service in a <a>Thing Directory</a>.
-      </p-->
+      <p class = "ednote">
+        The |query:DOMString| property was temporarily removed from
+        <a>ThingFilter</a>, until it is standardized in the WoT Discovery
+        task force. It represented a query string accepted by the implementation,
+        for instance a SPARQL or JSON query. Support was to be implemented locally
+        in the <a>WoT Runtime</a> or remotely as a service in a <a>Thing Directory</a>.
+      </p>
+      <p class="ednote">
+        The |url:USVString| property was removed. It used to represent the target
+        entity serving the discovery request, for instance the URL of a
+        <a>Thing Directory</a>, or the URL of a directly targeted <a>Thing</a>,
+        but these are implemented by dedicated methods now.
+      </p>
     </section>
 
     <section>
-      <h3>The <dfn>start()</dfn> method</h3>
+      <h3>The <dfn data-lt="generic-discovery">generic discovery</dfn> algorithm</h3>
       <div>
-        Starts the discovery process. The method MUST run the following steps:
+        Starts a generic discovery process by any means supported by the underlying
+        implementation, for instance by using multicast, preconfigured directory, etc.
+        The method, given |discovery:ThingDiscoveryProcess| and |discoveryMethod|
+        MUST run the following steps:
         <ol>
           <li>
-            If invoking this method is not allowed for the current scripting context for security reasons, set the <a href="#dom-thingdiscovery-error">error</a> property to a {{SecurityError}} and abort these steps.
+            Let |filter| denote the [[\filter]] internal slot of |discovery|.
           </li>
           <li>
-            If discovery is not supported by the implementation, set the <a href="#dom-thingdiscovery-error">error</a> property to {{NotSupportedError}} and abort these steps.
+            If |discoveryMethod| is `"generic"`, request the underlying platform
+            to start the discovery process by any means supported and
+            preconfigured in the <a>WoT Runtime</a> for which the script has
+            access to, passing |filter| to it.
           </li>
           <li>
-            Let |filter| denote the <a href="#dom-thingdiscovery-filter">filter</a> property.
-          </li>
-          <!--li>
-            If the |filter| is defined,
-            <ul>
-              <li>
-                If |filter|'s <a href="#dom-thingfilter-query">|query|</a> is defined, pass it as an opaque string to the underlying implementation to be matched against discovered items. The underlying implementation is responsible to parse it e.g. as a SPARQL or JSON query and match it against the <a>Thing Description</a>s found during the discovery process. If queries are not supported, set |this.error| to {{NotSupportedError}} and abort these steps.
-              </li>
-            </ul>
-          </li-->
-          <!-- <li>
-            Create the <a>discovery results</a> <a>internal slot</a> for storing discovered {{ThingDescription}} objects.
-          </li> -->
-          <li>
-            Request the underlying platform to start the discovery process, with the following parameters:
-            <ul>
-              <li>
-                If |filter|s <a href="#dom-thingfilter-method">|method|</a> is not defined or is `"directory"`, use the remote <a>Thing Directory</a> specified in |filter.url|.
-              </li>
-              <li>
-                Otherwise if |filter|s <a href="#dom-thingfilter-method">|method|</a> is `"direct"`, use the remote <a>Thing</a> specified in |filter.url|.
-              </li>
-            </ul>
-          </li>
-          <li>
-            When the underlying platform has started the discovery process, set the <a href="#dom-thingdiscovery-active">active</a> property to `true`.
-          </li>
-          <li>
-            Whenever a new <a>Thing Description</a> |td:ThingDescription| is discovered by the underlying platform, run the following sub-steps:
+            Otherwise if |discoveryMethod| is `"directory"`,
             <ol>
               <li>
-                Retrieve |td| as a JSON object using the <a>Protocol Binding</a> specified in the |filter.url| property.
-                In the case of an HTTP(S) Binding, this process could use the <a href="https://fetch.spec.whatwg.org/#fetch-api">Fetch API</a> for the |td|'s retrieval.
-                If that fails, set the <a href="#dom-thingdiscovery-error">error</a> property to {{SyntaxError}}, discard |td| and continue the discovery process.
+                Let |url:USVString| denote the [[\url]] <a>internal slot</a>
+                of |discovery|.
               </li>
+              <li>
+                Request the underlying platform to start the directory discovery
+                passing |url| and |filter| to it.
+              </li>
+            </ol>
+          </li>
+          <li>
+            Whenever a new link to a <a>Thing Description</a> |url:USVString|
+            is discovered and provided by the underlying platform, run the following
+            sub-steps:
+            <ol>
+              <li>
+                Retrieve |td:ThingDescription| as a JSON object, using the <a>Protocol Binding</a>
+                used by the underlying discovery process (as specified by |url|).
+                In the case of an HTTP(S) Binding, this process could use the
+                <a href="https://fetch.spec.whatwg.org/#fetch-api">Fetch API</a>
+                for the |td|'s retrieval.
+              </li>
+              <li>
+                If that fails, set the {{ThingDiscoveryProcess/error}}
+                property to {{SyntaxError}}, discard |td| and continue the discovery process.
+              </li>
+            </ol>
+          </li>
+          <li>
+            Whenever a <a>Thing Description</a> |td| is discovered and provided
+            by the underlying platform or by the previous step, run the following
+            sub-steps:
+            <p class="note">
+              At this point implementations MAY control the flow of the discovery
+              process (depending on memory constraints, for instance queue the
+              results, or temporarily stop discovery if the queue is getting too
+              large, or resume discovery when the queue is emptied sufficiently).
+              These steps are run for each discovered/fetched |td|.
+            </p>
+            <ol>
               <!--li>
                 If |filter|'s <a href="#dom-thingfilter-query">|query|</a> is defined, check if |json| is a match for the query. The matching algorithm is encapsulated by implementations. If that returns `false`, discard |td| and continue the discovery process.
               </li-->
               <li>
-                If |filter|'s <a href="#dom-thingfilter-fragment">|fragment|</a> is defined, for each property defined in it, check if that property exists in |json|'s properties and has the same value. If this is `false` in any checks, discard |td| and continue the discovery process.
+                If |filter|'s <a href="#dom-thingfilter-fragment">|fragment|</a>
+                is defined,
+                <ol> for each property defined in |fragment|,
+                  <li>
+                     Check if that property exists in |json|'s properties and has the same value.
+                  </li>
+                  <li>
+                    If this is `false` in any checks, discard |td|, discard these
+                    sub-steps and continue the discovery process.
+                  </li>
               </li>
               <li>
-                Otherwise return a {{Symbol/asyncIterator}} and yield the |td|.
-              </li>
-              <li>
-                At this point implementations MAY control the flow of the discovery process (depending on memory constraints, for instance temporarily stop discovery if the queue is getting too large, or resume discovery when the queue is emptied sufficiently).
+                Yield |td| using {{Symbol/asyncIterator}}.
+                <p class="ednote">
+                  Improve this step using proper asyncIterator terminology.
+                </p>
               </li>
             </ol>
           </li>
           <li>
             Whenever an error occurs during the discovery process,
+            <p class="note">
+              The last error is retained. Implementations MAY choose to stop the
+              discovery process if they consider it should be reported.
+            </p>
             <ol>
               <li>
-                Let |error| be a new {{Error}} object. Set |error|'s |name| to `"DiscoveryError"`.
+                Let |error| be a new {{Error}} object.
+                Set |error|'s |name| to `"DiscoveryError"`.
               </li>
               <li>
-                 If there was an error code or message provided by the <a>Protocol Bindings</a>, set |error|'s |message| to that value as string.
+                 If there was an error code or message provided by the
+                 <a>Protocol Bindings</a>, set |error|'s |message| to that value as string.
               </li>
               <li>
-                Set <a href="#dom-thingdiscovery-error">error</a> property to |error|.
+                Set {{ThingDiscoveryProcess/error}} property to |error|.
               </li>
               <li>
-                If the error is irrecoverable and discovery has been stopped by the underlying platform, set the <a href="#dom-thingdiscovery-active">active</a> property to `false`.
+                If the error is irrecoverable and discovery has been stopped by
+                the underlying platform, or if the implementation decided to
+                stop the discovery process and report the error, continue to the
+                next step.
               </li>
             </ol>
           </li>
           <li>
-            When the underlying platform reports the discovery process has completed, set the <a href="#dom-thingdiscovery-active">active</a> property to `false`.
+            If the discovery process has been stopped for any reason (completion
+            or error), set the {{ThingDiscoveryProcess/done}} property to `true`
+            and terminate these steps.
           </li>
         </ol>
       </div>
-    </section>
-
+   </section>
+<!--
     <section>
-      <h3>The <dfn>next()</dfn> method</h3>
+      <h3>The <dfn>next()</dfn> method of {{Symbol/asyncIterator}}</h3>
       <div>
         Provides the next discovered {{ThingDescription}} object. The method MUST run the following steps:
         <ol>
@@ -3818,10 +3935,11 @@
             Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
           </li>
           <li>
-            If the <a href="#dom-thingdiscovery-active">active</a> property is `true`, call the `next` method on the Discovery object's {{Symbol/asyncIterator}}.
+            Call the `next` method on the Discovery object's {{Symbol/asyncIterator}}.
           </li>
           <li>
-            If the `value` property in the yielded result from the {{Symbol/asyncIterator}} is undefined and the `done` property is set to `true`, set the <a href="#dom-thingdiscovery-done">done</a> property to `true` and reject |promise|.
+            If the `value` property in the yielded result from the {{Symbol/asyncIterator}} is undefined, set the
+            {{ThingDiscoveryProcess/done}} property to `true` and reject |promise|.
           </li>
           <li>
             Resolve |promise| with |td| and abort these steps.
@@ -3829,17 +3947,20 @@
         </ol>
       </div>
     </section>
-
+-->
     <section>
       <h3>The <dfn>stop()</dfn> method</h3>
       <div>
-        Stops or suppresses the discovery process. It might not be supported by all discovery methods and endpoints, however, any further discovery results or errors will be discarded and the discovery is marked inactive. The method MUST run the following steps:
+        Stops or suppresses the discovery process. It might not be supported by all discovery methods and endpoints, however, any further discovery results or errors will be discarded and the discovery is marked as done. The method MUST run the following steps:
         <ol>
+          <li>
+            If invoking this method is not allowed for the current scripting context for security reasons, [= exception/throw =] a {{SecurityError}} and abort these steps.
+          </li>
           <li>
             Request the underlying platform to stop the discovery process. If this returns an error, or if it is not possible, for instance when discovery is based on open ended multicast requests, the implementation SHOULD discard subsequent discovered items.
           </li>
           <li>
-            Set the <a href="#dom-thingdiscovery-active">active</a> property to `false`.
+            Set the {{ThingDiscoveryProcess/done}} property to `true`.
           </li>
         </ol>
       </div>
@@ -3852,51 +3973,47 @@
         Using the {{Symbol/asyncIterator}} provided by the Discovery object, we can iterate asynchronously over the results and perform operations with the obtained {{ThingDescription}} objects.
       </p>
       <pre class="example" title="Fetch the Thing Description of a Thing">
-        let discovery = new ThingDiscovery({ method: "direct" });
-        for await (let td of discovery) {
-          console.log("Found Thing Description for " + td.title);
-        }
+        let url = "https://mythings.com/thing1";
+        let td = await WOT.requestThingDescription(url);
+        console.log("Found Thing Description for " + td.title);
       </pre>
       <p>
         The next example finds {{ThingDescription}} objects of <a>Thing</a>s listed in a <a>Thing Directory</a> service. We set a timeout for safety.
       </p>
       <pre class="example" title="Discover Things via directory">
-        let discoveryFilter = {
-          method: "directory", // default value, no need to specify
-          url: "http://directory.wotservice.org"
-        };
-        let discovery = new ThingDiscovery(discoveryFilter);
+        let discovery = WOT.exploreDirectory("http://directory.wotservice.org");
         setTimeout( () => {
             discovery.stop();
             console.log("Discovery stopped after timeout.");
           },
           3000);
-        do {
-          let td = await discovery.next();
+        for await (const td of discovery) {
           console.log("Found Thing Description for " + td.title);
           let thing = new ConsumedThing(td);
           console.log("Thing name: " + thing.getThingDescription().title);
-        } while (!discovery.done);
+        };
         if (discovery.error) {
           console.log("Discovery stopped because of an error: " + error.message);
         }
       </pre>
-      <!--p>
-        The next example is for an open-ended multicast discovery, which likely won't complete soon (depending on the underlying protocol), so stopping it with a timeout is a good idea. It will likely deliver results one by one.
+      <p>
+        The next example is for a generic discovery, by any means provisioned
+        to the WOT runtime, including local Things, if any is available.
       </p>
       <pre class="example" title="Discover Things in a network">
-        let discovery = new ThingDiscovery({ method: "multicast" });
+        let discovery = WOT.discover();
         setTimeout( () => {
             discovery.stop();
             console.log("Stopped open-ended discovery");
           },
           10000);
-        do {
-          let td = await discovery.next();
-          let thing = new ConsumedThing(td);
-          console.log("Thing name: " + thing.getThingDescription().title);
-        } while (!discovery.done);
-      </pre-->
+        for await (const td of discovery) {
+          console.log("Found Thing Description for " + td.title);
+        };
+        if (discovery.error) {
+          console.log("Discovery stopped because of an error: " + error.message);
+        }
+      </pre>
     </section> <!-- Examples -->
   </section>
 

--- a/index.html
+++ b/index.html
@@ -738,9 +738,13 @@
           Set |discovery|'s {{ThingDiscoveryProcess/[[url]]}} to `undefined`.
         </li>
         <li>
-          If |filter| is not supported by the implementation, or if discovery
-          cannot be started by the underlying platform,
-          reject |promise| with {{NotSupportedError}} and abort these steps.
+          If filters in general are not supported by the implementation and
+          |filter| is not `undefined` or `null`, reject |promise|
+          with {{NotSupportedError}} and abort these steps.
+        </li>
+        <li>
+          If discovery cannot be started by the underlying platform,
+          reject |promise| with {{OperationError}} and abort these steps.
         </li>
         <li>
           Request the underlying platform to start the <a>discovery process</a>
@@ -799,8 +803,9 @@
               with {{NotSupportedError}} and terminate these steps.
             </li>
             <li>
-              If |filter| is not supported by the implementation, reject |promise|
-              with {{NotSupportedError}} and terminate these steps.
+              If filters in general are not supported by the implementation and
+              |filter| is not `undefined` or `null`, reject |promise|
+              with {{NotSupportedError}} and abort these steps.
             </li>
             <li>
               Run the <a>discovery process</a> given |discovery|.

--- a/index.html
+++ b/index.html
@@ -66,6 +66,12 @@
             publisher: "W3C",
             date: "24 November 2020"
           },
+          "WOT-DISCOVERY" : {
+            href:"https://www.w3.org/TR/2022/WD-wot-discovery-20220810/",
+            title: "Web of Things (WoT) Discovery",
+            publisher: "W3C",
+            date: "10 August 2022"
+          },
           "WOT-PROTOCOL-BINDINGS" : {
             href: "https://www.w3.org/TR/2020/NOTE-wot-binding-templates-20200130/",
             title: "Web of Things Binding Templates",
@@ -170,7 +176,7 @@
     </p>
     <p>
       Scripting is an optional building block in WoT and it is typically used in gateways or browsers that are able to run a <a>WoT Runtime</a> and
-      <a href="https://github.com/w3c/wot-scripting-api/tree/master/applications/script-manager">script management</a>, providing a convenient way to extend WoT support to new types of endpoints and implement WoT applications such as <a href="https://github.com/w3c/wot-scripting-api/tree/master/applications/thing-directory">Thing Directory</a>.
+      <a href="https://github.com/w3c/wot-scripting-api/tree/master/applications/script-manager">script management</a>, providing a convenient way to extend WoT support to new types of endpoints and implement WoT applications such as <a href="https://github.com/w3c/wot-scripting-api/tree/master/applications/thing-directory">TD Directory</a>.
     </p>
     <p>
       This specification describes an application programming interface (API) representing the <a>WoT Interface</a> that allows scripts to discover, operate <a>Thing</a>s and to expose locally defined <a>Thing</a>s characterized by <a> WoT Interactions</a> specified by a script.
@@ -726,15 +732,20 @@
           Let |discovery:ThingDiscoveryProcess| be a new {{ThingDiscoveryProcess}} object.
         </li>
         <li>
-          Set |discovery|'s [[\filter]] <a>internal slot</a> to |filter:ThingFilter| or
-          `undefined`.
+          Set |discovery|'s {{ThingDiscoveryProcess/[[filter]]}} to |filter:ThingFilter|.
         </li>
         <li>
-          Set |discovery|'s [[\url]] <a>internal slot</a> to `undefined`.
+          Set |discovery|'s {{ThingDiscoveryProcess/[[url]]}} to `undefined`.
         </li>
         <li>
-          Invoke the <a>generic discovery</a>
-          algorithm given |discovery:ThingDiscoveryProcess| and <code>`"generic"`</code>.
+          If |filter| is not supported by the implementation, or if discovery
+          cannot be started by the underlying platform,
+          reject |promise| with {{NotSupportedError}} and abort these steps.
+        </li>
+        <li>
+          Request the underlying platform to start the <a>discovery process</a>
+          by any means supported and provisioned in the <a>WoT Runtime</a> for which
+          the script has access to, passing |discovery| to it.
         </li>
         <li>
           Resolve |promise| with |discovery|.
@@ -767,15 +778,38 @@
           Let |discovery:ThingDiscoveryProcess| be a new {{ThingDiscoveryProcess}} object.
         </li>
         <li>
-          Set |discovery|'s [[\url]] <a>internal slot</a> to |url:USVString|.
+          Set |discovery|'s {{ThingDiscoveryProcess/[[url]]}} to |url:USVString|.
         </li>
         <li>
-          Set |discovery|'s [[\filter]] <a>internal slot</a> to |filter:ThingFilter|
-          or `undefined`.
+          Set |discovery|'s {{ThingDiscoveryProcess/[[filter]]}} to |filter:ThingFilter|.
         </li>
         <li>
-          Invoke the <a href="#the-generic-discovery-algorithm">generic discovery</a>
-          algorithm given |discovery:ThingDiscoveryProcess| and <code>`"directory"`</code>.
+          Request the underlying platform to start the directory discovery process.
+          <p class="note">
+            This is a placeholder for more details in the discovery algorithm.
+            Implementations should follow the procedures described in the
+            [[WOT-DISCOVERY]] and [WOT-PROTOCOL-BINDINGS] specifications.
+            Some normative steps are indicated below.
+          </p>
+          <ol>
+            <li>
+              If |url| is not a <a>TD Directory</a> or if the underlying
+              implementation cannot support the <a>Protocol Binding</a>
+              indicated by |url|, reject |promise|
+              with {{NotSupportedError}} and terminate these steps.
+            </li>
+            <li>
+              If |filter| is not supported by the implementation, reject |promise|
+              with {{NotSupportedError}} and terminate these steps.
+            </li>
+            <li>
+              Run the <a>discovery process</a> given |discovery|.
+              <p class="note">
+                From this point on, errors are recorded only on
+                {{ThingDiscoveryProcess/error}}, but don't affect |promise| any longer.
+              </p>
+            </li>
+          </ol>
         </li>
         <li>
           Resolve |promise| with |discovery|.
@@ -799,7 +833,9 @@
           Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
         </li>
         <li>
-          If invoking this method is not allowed for the current scripting context for security reasons, reject |promise| with a {{SecurityError}} and abort these steps.
+          If invoking this method is not allowed for the current scripting
+          context for security reasons, reject |promise| with a {{SecurityError}}
+          and abort these steps.
         </li>
         <li>
           If fetching a <a>Thing Description</a> is not supported by the
@@ -3729,12 +3765,12 @@
       </thead>
       <tbody data-link-for="ThingDiscoveryProcess">
        <tr>
-        <td>[[\filter]]</td>
+        <td><dfn>[[\filter]]</dfn></td>
         <td>`undefined`</td>
         <td>The {{ThingFilter}} object used in discovery.</td>
        </tr>
       <tr>
-        <td>[[\url]]</td>
+        <td><dfn>[[\url]]</dfn></td>
         <td>`undefined`</td>
         <td>A {{URL}} representing the <a>TD Directory</a> in a discovery.</td>
       </tr>
@@ -3764,13 +3800,13 @@
             Let |discovery:ThingDiscoveryProcess| be a new {{ThingDiscoveryProcess}} object.
           </li>
           <li>
-            Set the [[\filter]] <a>internal slot</a> to |filter|.
+            Set |discovery|.{{ThingDiscoveryProcess/[[filter]]}} to |filter|.
           </li>
           <li>
-            Set the {{ThingDiscoveryProcess/done}} property to `false`.
+            Set |discovery|.{{ThingDiscoveryProcess/done}} to `false`.
           </li>
           <li>
-            Set the {{ThingDiscoveryProcess/error}} property to `null`.
+            Set |discovery|.{{ThingDiscoveryProcess/error}} to `null`.
           </li>
           <li>
             Return |discovery|.
@@ -3809,49 +3845,25 @@
     </section>
 
     <section>
-      <h3>The <dfn data-lt="generic-discovery">generic discovery</dfn> algorithm</h3>
+      <h3>The <dfn data-lt="discovery-process">discovery process</dfn> algorithm</h3>
       <div>
-        Starts a generic discovery process by any means supported by the underlying
-        implementation, for instance by using multicast, preconfigured directory, etc.
-        The method, given |discovery:ThingDiscoveryProcess| and |discoveryMethod|
-        MUST run the following steps:
+        Describes what to do during a discovery process that has already started.
+        The algorithm, given |discovery:ThingDiscoveryProcess|, runs the following steps:
         <ol>
           <li>
-            Let |filter| denote the [[\filter]] internal slot of |discovery|.
-          </li>
-          <li>
-            If |discoveryMethod| is `"generic"`, request the underlying platform
-            to start the discovery process by any means supported and
-            preconfigured in the <a>WoT Runtime</a> for which the script has
-            access to, passing |filter| to it.
-          </li>
-          <li>
-            Otherwise if |discoveryMethod| is `"directory"`,
-            <ol>
-              <li>
-                Let |url:USVString| denote the [[\url]] <a>internal slot</a>
-                of |discovery|.
-              </li>
-              <li>
-                Request the underlying platform to start the directory discovery
-                passing |url| and |filter| to it.
-              </li>
-            </ol>
-          </li>
-          <li>
-            Whenever a new link to a <a>Thing Description</a> |url:USVString|
+            Whenever a new |link| to a <a>Thing Description</a>
             is discovered and provided by the underlying platform, run the following
             sub-steps:
             <ol>
               <li>
                 Retrieve |td:ThingDescription| as a JSON object, using the <a>Protocol Binding</a>
-                used by the underlying discovery process (as specified by |url|).
+                used by the underlying discovery process (as specified by |link|).
                 In the case of an HTTP(S) Binding, this process could use the
                 <a href="https://fetch.spec.whatwg.org/#fetch-api">Fetch API</a>
                 for the |td|'s retrieval.
               </li>
               <li>
-                If that fails, set the {{ThingDiscoveryProcess/error}}
+                If that fails, set the |discovery|.{{ThingDiscoveryProcess/error}}
                 property to {{SyntaxError}}, discard |td| and continue the discovery process.
               </li>
             </ol>
@@ -3872,9 +3884,9 @@
                 If |filter|'s <a href="#dom-thingfilter-query">|query|</a> is defined, check if |json| is a match for the query. The matching algorithm is encapsulated by implementations. If that returns `false`, discard |td| and continue the discovery process.
               </li-->
               <li>
-                If |filter|'s <a href="#dom-thingfilter-fragment">|fragment|</a>
-                is defined,
-                <ol> for each property defined in |fragment|,
+                If |discovery|.{{ThingDiscoveryProcess/[[filter]]}}.{{ThingFilter/fragment}}
+                [=map/exists=], then for each property defined in it,
+                <ol>
                   <li>
                      Check if that property exists in |json|'s properties and has the same value.
                   </li>
@@ -3882,6 +3894,7 @@
                     If this is `false` in any checks, discard |td|, discard these
                     sub-steps and continue the discovery process.
                   </li>
+                </ol>
               </li>
               <li>
                 Yield |td| using {{Symbol/asyncIterator}}.
@@ -3892,7 +3905,8 @@
             </ol>
           </li>
           <li>
-            Whenever an error occurs during the discovery process,
+            Whenever an error occurs during the discovery process, run the following
+            sub-steps:
             <p class="note">
               The last error is retained. Implementations MAY choose to stop the
               discovery process if they consider it should be reported.
@@ -3907,20 +3921,16 @@
                  <a>Protocol Bindings</a>, set |error|'s |message| to that value as string.
               </li>
               <li>
-                Set {{ThingDiscoveryProcess/error}} property to |error|.
+                Set |discovery|.{{ThingDiscoveryProcess/error}} to |error|.
               </li>
               <li>
                 If the error is irrecoverable and discovery has been stopped by
                 the underlying platform, or if the implementation decided to
-                stop the discovery process and report the error, continue to the
-                next step.
+                stop the discovery process and report the error, set
+                |discovery|.{{ThingDiscoveryProcess/done}} to `true` and
+                terminate these steps.
               </li>
             </ol>
-          </li>
-          <li>
-            If the discovery process has been stopped for any reason (completion
-            or error), set the {{ThingDiscoveryProcess/done}} property to `true`
-            and terminate these steps.
           </li>
         </ol>
       </div>


### PR DESCRIPTION
Introduce separate methods for requesting to fetch a TD, for directory discovery and for generic discovery.
Rename ThingDiscovery to ThingDiscoveryProcess.
Remove |url| from ThingFilter and make it internal slot to ThingDiscoveryProcess. Remove |filter| from ThingDiscoveryProcess and make it internal slot to ThingDiscoveryProcess. Remove |active| from ThingDiscoveryProcess.
Define a generic discovery algorithm with meta-argument for generic or directory discovery.
Add the URL standard to the document header / xref.
Address #364
Signed-off-by: Zoltan Kis <zoltan.kis@intel.com>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/zolkis/wot-scripting-api/pull/441.html" title="Last updated on Dec 19, 2022, 12:32 PM UTC (27f9442)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/441/6fcfdb6...zolkis:27f9442.html" title="Last updated on Dec 19, 2022, 12:32 PM UTC (27f9442)">Diff</a>