### PR TITLE
fix: emitEvent() method allows data to be optional

### DIFF
--- a/index.html
+++ b/index.html
@@ -3369,7 +3369,7 @@
           </li>
           <li>
             Make a request to the underlying platform to emit an <a>Event</a>
-            with optionally |data|. Call the <a href="#handling-events">handling events</a>
+            with optional |data|. Call the <a href="#handling-events">handling events</a>
             steps.
           </li>
         </ol>

--- a/index.html
+++ b/index.html
@@ -2398,7 +2398,7 @@
         ExposedThing setEventUnsubscribeHandler(DOMString name,
                 EventSubscriptionHandler handler);
         Promise&lt;undefined&gt; emitEvent(DOMString name,
-                InteractionInput data);
+                optional InteractionInput data = null);
 
         Promise&lt;undefined&gt; expose();
         Promise&lt;undefined&gt; destroy();
@@ -3350,8 +3350,8 @@
     <section> <h3>The <dfn>emitEvent()</dfn> method</h3>
       <div>
         Takes as arguments |name:string| denoting an <a>Event</a> name and
-        |data:InteractionInput|.
-        Triggers emitting the <a>Event</a> with the given data.
+        optionally |data:InteractionInput|.
+        Triggers emitting the <a>Event</a> with the optional data.
         The method MUST run the following steps:
         <ol>
           <li>
@@ -3369,7 +3369,7 @@
           </li>
           <li>
             Make a request to the underlying platform to emit an <a>Event</a>
-            with |data|. Call the <a href="#handling-events">handling events</a>
+            with optionally |data|. Call the <a href="#handling-events">handling events</a>
             steps.
           </li>
         </ol>

--- a/index.html
+++ b/index.html
@@ -2398,7 +2398,7 @@
         ExposedThing setEventUnsubscribeHandler(DOMString name,
                 EventSubscriptionHandler handler);
         Promise&lt;undefined&gt; emitEvent(DOMString name,
-                optional InteractionInput data = null);
+                optional InteractionInput data);
 
         Promise&lt;undefined&gt; expose();
         Promise&lt;undefined&gt; destroy();

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -549,7 +549,7 @@
     },
     "scripting-api": {
       "name": "wot-typescript-definitions",
-      "version": "0.8.0-SNAPSHOT.23",
+      "version": "0.8.0-SNAPSHOT.24",
       "license": "W3C-20150513",
       "devDependencies": {
         "json-schema-to-typescript": "^10.1.4"

--- a/typescript/scripting-api/index.d.ts
+++ b/typescript/scripting-api/index.d.ts
@@ -277,10 +277,10 @@ declare namespace WoT {
         setEventUnsubscribeHandler(name: string, handler: EventSubscriptionHandler): ExposedThing;
 
         /**
-         * Takes as arguments name denoting an Event name and data.
-         * Triggers emitting the Event with the given data. 
+         * Takes as arguments name denoting an Event name and optionally data.
+         * Triggers emitting the Event with optional data.
          */
-        emitEvent(name: string, data: InteractionInput): void;
+        emitEvent(name: string, data?: InteractionInput): void;
 
         /**
          * Returns the the object that represents the Thing Description.

--- a/typescript/scripting-api/package.json
+++ b/typescript/scripting-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wot-typescript-definitions",
-  "version": "0.8.0-SNAPSHOT.23",
+  "version": "0.8.0-SNAPSHOT.24",
   "description": "TypeScript definitions for the W3C WoT Scripting API",
   "author": "W3C Web of Things Working Group",
   "license": "W3C-20150513",


### PR DESCRIPTION
resolves https://github.com/w3c/wot-scripting-api/issues/402


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-scripting-api/pull/442.html" title="Last updated on Dec 14, 2022, 12:37 PM UTC (c323d8a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/442/6fcfdb6...danielpeintner:c323d8a.html" title="Last updated on Dec 14, 2022, 12:37 PM UTC (c323d8a)">Diff</a>