### PR TITLE
fix: "Intel" usage to "Intel Corp."

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
         noIDLIn:              true,
 		noRecTrack:           true,
         editors: [
-          { name: "Zoltan Kis", w3cid: "57789", company: "Intel", companyURL: "https://www.intel.com/" },
+          { name: "Zoltan Kis", w3cid: "57789", company: "Intel Corp.", companyURL: "https://www.intel.com/" },
           { name: "Daniel Peintner", w3cid: "39497", company: "Siemens AG", companyURL: "https://www.siemens.com/" },
           { name: "Cristiano Aguzzi", w3cid: "105495", company: "Invited Expert", companyURL: "https://github.com/relu91" },
           { name: "Johannes Hund", w3cid: "74472", note: "Former Editor, when at Siemens AG" },


### PR DESCRIPTION
Align with changes in other repos, e.g, https://github.com/w3c/wot-thing-description/pull/1899

@zolkis


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Oct 18, 2023, 1:37 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fwot-scripting-api%2F119c2a0dae2f53cd53b7baf81180b75b3bd025e3%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
Specification: http://labs.w3.org/spec-generator/uploads/qSQ3Yy/index.html?isPreview=true%3FisPreview%3Dtrue&publishDate=2023-10-18
ReSpec version: 34.2.0
File a bug: https://github.com/w3c/respec/
Error: undefined

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/wot-scripting-api%23511.)._
</details>
