### PR TITLE
feat!(typescript): align TypeScript definitions with Discovery API

### DIFF
--- a/typescript/scripting-api/index.d.ts
+++ b/typescript/scripting-api/index.d.ts
@@ -61,6 +61,7 @@ declare namespace WoT {
      * controlling the discovery process. 
      */
     export interface ThingDiscoveryProcess extends AsyncIterable<ThingDescription> {
+        new(filter?: ThingFilter);
         filter?: ThingFilter;
         done: boolean;
         error?: Error;

--- a/typescript/scripting-api/index.d.ts
+++ b/typescript/scripting-api/index.d.ts
@@ -12,7 +12,7 @@ declare namespace WoT {
      *
      * @param filter represents the constraints for discovering Things as key-value pairs
      */
-    export function discover(filter?: ThingFilter): ThingDiscoveryProcess;
+    export function discover(filter?: ThingFilter): Promise<ThingDiscoveryProcess>;
 
     /**
      * Starts the discovery process that, given a TD Directory {@link url}, will

--- a/typescript/scripting-api/index.d.ts
+++ b/typescript/scripting-api/index.d.ts
@@ -51,10 +51,6 @@ declare namespace WoT {
      */
     export interface ThingFilter {
         /**
-         * The query field represents a query string accepted by the implementation, for instance a SPARQL query.
-         */
-        query?: string;
-        /**
          * The fragment field represents a template object used for matching against discovered Things.
          */
         fragment?: object;

--- a/typescript/scripting-api/index.d.ts
+++ b/typescript/scripting-api/index.d.ts
@@ -64,8 +64,6 @@ declare namespace WoT {
         filter?: ThingFilter;
         done: boolean;
         error?: Error;
-        start(): void;
-        next(): Promise<ThingDescription>;
         stop(): void;
     }
 

--- a/typescript/scripting-api/index.d.ts
+++ b/typescript/scripting-api/index.d.ts
@@ -6,11 +6,30 @@ type DeepPartial<T> = T extends object ? {
 declare namespace WoT {
 
     /**
-     * Starts the discovery process that will provide ConsumedThing 
-     * 
+     * Starts the discovery process that will provide {@link ThingDescription}
+     * objects for Thing Descriptions that match an optional {@link filter}
+     * argument of type {@link ThingFilter}.
+     *
      * @param filter represents the constraints for discovering Things as key-value pairs
      */
-    export function discover(filter?: ThingFilter): ThingDiscovery;
+    export function discover(filter?: ThingFilter): ThingDiscoveryProcess;
+
+    /**
+     * Starts the discovery process that, given a TD Directory {@link url}, will
+     *  provide {@link ThingDescription} objects for Thing Descriptions that
+     * match an optional {@link filter} argument of type {@link ThingFilter}.
+     *
+     * @param url URL pointing to a TD Directory.
+     * @param filter represents the constraints for discovering Things as key-value pairs
+     */
+    export function exploreDirectory(url: string, filter?: ThingFilter): Promise<ThingDiscoveryProcess>;
+
+    /**
+     * Requests a {@link ThingDescription} from the given {@link url}.
+     *
+     * @param url The URL to request the Thing Description from.
+     */
+    export function requestThingDescription(url: string): Promise<ThingDescription>;
 
     /**
      * Accepts a ThingDescription and returns a ConsumedThing
@@ -32,15 +51,7 @@ declare namespace WoT {
      */
     export interface ThingFilter {
         /**
-         * The method field represents the discovery type that should be used in the discovery process. The possible values are defined by the DiscoveryMethod enumeration that can be extended by string values defined by solutions (with no guarantee of interoperability). 
-         */
-        method?: DiscoveryMethod | string; // default value "any", DOMString
-        /**
-         * The url field represents additional information for the discovery method, such as the URL of the target entity serving the discovery request, such as a Thing Directory or a Thing.
-         */
-        url?: string;
-        /**
-         * The query field represents a query string accepted by the implementation, for instance a SPARQL query. 
+         * The query field represents a query string accepted by the implementation, for instance a SPARQL query.
          */
         query?: string;
         /**
@@ -49,25 +60,12 @@ declare namespace WoT {
         fragment?: object;
     }
 
-    /** The DiscoveryMethod enumeration represents the discovery type to be used */
-    export enum DiscoveryMethod {
-        /** does not restrict */
-        "any",
-        /** for discovering Things defined in the same Servient */
-        "local",
-        /** for discovery based on a service provided by a Thing Directory */
-        "directory",
-        /** for discovering Things in the same/reachable network by using a supported multicast protocol */
-        "multicast"
-    }
-
     /**
      * The ThingDiscovery object is constructed given a filter and provides the properties and methods
      * controlling the discovery process. 
      */
-    export interface ThingDiscovery {
+    export interface ThingDiscoveryProcess extends AsyncIterable<ThingDescription> {
         filter?: ThingFilter;
-        active: boolean;
         done: boolean;
         error?: Error;
         start(): void;

--- a/typescript/scripting-api/index.d.ts
+++ b/typescript/scripting-api/index.d.ts
@@ -61,7 +61,6 @@ declare namespace WoT {
      * controlling the discovery process. 
      */
     export interface ThingDiscoveryProcess extends AsyncIterable<ThingDescription> {
-        new(filter?: ThingFilter);
         filter?: ThingFilter;
         done: boolean;
         error?: Error;

--- a/typescript/scripting-api/package.json
+++ b/typescript/scripting-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wot-typescript-definitions",
-  "version": "0.8.0-SNAPSHOT.28",
+  "version": "0.8.0-SNAPSHOT.29",
   "description": "TypeScript definitions for the W3C WoT Scripting API",
   "author": "W3C Web of Things Working Group",
   "license": "W3C-20150513",


### PR DESCRIPTION
In the context of https://github.com/eclipse-thingweb/node-wot/pull/864, I noticed that the TypeScript definitions are not taking into account the latest changes to the Scripting APIs discovery API (see https://github.com/w3c/wot-scripting-api/pull/405 and https://github.com/w3c/wot-scripting-api/pull/441). This PR should adjust the types accordingly – let me know if I missed anything :)