### PR TITLE
feat(typescript): add constructor to ConsumedThing interface

### DIFF
--- a/typescript/scripting-api/index.d.ts
+++ b/typescript/scripting-api/index.d.ts
@@ -106,6 +106,10 @@ declare namespace WoT {
      */
     export interface ConsumedThing {
         /**
+         * Instantiates a new ConsumedThing from a {@link ThingDescription}.
+         */
+        new(td: ThingDescription);
+        /**
          * Reads a Property value.
          * Takes as arguments propertyName and optionally options.
          * It returns a Promise that resolves with a Property value represented as an


### PR DESCRIPTION
Corresponding with the discussion in https://github.com/w3c/wot-scripting-api/pull/513#discussion_r1369907606, this PR adds a constructor parameter to the TypeScript definition of the `ConsumedThing` interface.

In this context, I noticed that we might want to also add a constructor to both the WebIDL and TypeScript definitions of the `ExposedThing` interface.