### PR TITLE
feat!: remove constructor from ConsumedThing interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -1378,7 +1378,6 @@
     <pre class="idl">
       [SecureContext, Exposed=(Window,Worker)]
       interface ConsumedThing {
-        constructor(ThingDescription td);
         Promise&lt;InteractionOutput&gt; readProperty(DOMString propertyName,
                                     optional InteractionOptions options = {});
         Promise&lt;PropertyReadMap&gt; readAllProperties(

--- a/index.html
+++ b/index.html
@@ -585,12 +585,6 @@
           [=Resolve=] |promise| with |thing|.
         </li>
       </ol>
-      <p class="ednote">
-        Note the difference between constructing <a>ConsumedThing</a> and using
-        the <code>consume()</code> method: the latter also initializes the protocol
-        bindings, whereas a simple constructed object will not have <a>WoT Interactions</a>
-        initialized until they are invoked.
-      </p>
     </div>
   </section>
 
@@ -1475,7 +1469,7 @@
     </section>
 
     <section>
-      <h4>Constructing <code>ConsumedThing</code></h4>
+      <h4>Creating <code>ConsumedThing</code></h4>
       <p>
         After <a href="#fetching-a-thing-description">fetching</a> a
         <a>Thing Description</a> as a JSON object, one can create a
@@ -2653,10 +2647,10 @@
     </section>
 
     <section>
-      <h3>Constructing {{ExposedThing}}</h3>
+      <h3>Creating {{ExposedThing}}</h3>
       <p>
-        The {{ExposedThing}} interface extends {{ConsumedThing}}. It
-        is constructed from a full or partial {{ThingDescription}} object.
+        The {{ExposedThing}} interface
+        is created from a full or partial {{ThingDescription}} object.
       </p>
       <p class="note">
          Note that an existing {{ThingDescription}} object can be optionally modified (for instance by adding or removing elements on its |properties|, |actions| and |events| internal properties) and the resulting object can used for constructing an
@@ -2664,7 +2658,7 @@
          removing <a>Property</a>, <a>Action</a> and <a>Event</a> definitions, as illustrated in the <a href="#exposedthing-examples">examples</a>.
       </p>
       <p class="note">
-        Before invoking <a href="#dom-exposedthing-expose">expose()</a>, the {{ExposedThing}} object does not serve any requests. This allows first constructing {{ExposedThing}} and then initialize its <a>Properties</a> and service handlers before starting serving requests.
+        Before invoking <a href="#dom-exposedthing-expose">expose()</a>, the {{ExposedThing}} object does not serve any requests. This allows first creating {{ExposedThing}} and then initialize its <a>Properties</a> and service handlers before starting serving requests.
       </p>
       <div>
         To construct an {{ExposedThing}} with the {{ExposedThingInit}}

--- a/index.html
+++ b/index.html
@@ -2653,7 +2653,7 @@
         is created from a full or partial {{ThingDescription}} object.
       </p>
       <p class="note">
-         Note that an existing {{ThingDescription}} object can be optionally modified (for instance by adding or removing elements on its |properties|, |actions| and |events| internal properties) and the resulting object can used for constructing an
+         Note that an existing {{ThingDescription}} object can be optionally modified (for instance by adding or removing elements on its |properties|, |actions| and |events| internal properties) and the resulting object can used for creating an
          {{ExposedThing}} object. This is the current way of adding and
          removing <a>Property</a>, <a>Action</a> and <a>Event</a> definitions, as illustrated in the <a href="#exposedthing-examples">examples</a>.
       </p>
@@ -2661,7 +2661,7 @@
         Before invoking <a href="#dom-exposedthing-expose">expose()</a>, the {{ExposedThing}} object does not serve any requests. This allows first creating {{ExposedThing}} and then initialize its <a>Properties</a> and service handlers before starting serving requests.
       </p>
       <div>
-        To construct an {{ExposedThing}} with the {{ExposedThingInit}}
+        To create an {{ExposedThing}} with the {{ExposedThingInit}}
         |init:ExposedThingInit|, run the following steps:
         <ol>
           <li>
@@ -4290,11 +4290,6 @@
         is defined externally in the [[[WOT-TD]]] specification, that is scoped out, too.
         This specification expects a <a>TD</a> as
         <a data-cite="infra#parse-json-bytes-to-a-javascript-value">parsed JSON object</a> that has been validated according to the [[[WOT-TD]]] specification.
-      </p>
-    </section>
-    <section> <h4>Factory vs constructors</h4>
-      <p>
-        The factory methods for consuming and exposing <a>Thing</a>s are asynchronous and fully validate the input <a>TD</a>. In addition, one can also construct {{ConsumedThing}} and {{ExposedThing}} by providing a parsed and validated <a>TD</a>. Platform initialization is then done when needed during the WoT interactions.
       </p>
     </section>
     <section> <h4>Observers</h4>


### PR DESCRIPTION
Would resolve #516 and close #515 (as an alternative PR).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-scripting-api/pull/517.html" title="Last updated on Oct 29, 2023, 10:06 PM UTC (03b740d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/517/119c2a0...JKRhb:03b740d.html" title="Last updated on Oct 29, 2023, 10:06 PM UTC (03b740d)">Diff</a>