### PR TITLE
Use simple single and double quotes in code examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -2400,7 +2400,7 @@
         };
 
         try {
-          // subscribe to property change for “temperature”
+          // subscribe to property change for "temperature"
           await thing.observeProperty("temperature", async (data) => {
             try {
               console.log("Temperature changed to: " + await data.value());
@@ -2409,11 +2409,11 @@
               console.error(error);
             }
           });
-          // subscribe to the “ready” event defined in the TD
+          // subscribe to the "ready" event defined in the TD
           await thing.subscribeEvent("ready", async (eventData) => {
             try {
               console.log("Ready; index: " + await eventData.value());
-              // run the “startMeasurement” action defined by TD
+              // run the "startMeasurement" action defined by TD
               await thing.invokeAction("startMeasurement", { units: "Celsius" });
               console.log("Measurement started.");
             } catch (error) {
@@ -2457,7 +2457,7 @@
         let response;
         let image;
         try {
-          response = await thing.invokeAction(“takePicture”));
+          response = await thing.invokeAction("takePicture");
           image = await response.value() // throws NotReadableError --> schema not defined
         } catch(ex) {
           image = await response.arrayBuffer();
@@ -2519,7 +2519,7 @@
         parser.on('data', data => data.name === 'startObject' && ++objectCounter);
         parser.on('end', () => console.log(`Found ${objectCounter} objects.`));
 
-        const response = await thing.readProperty(“eventHistory”)
+        const response = await thing.readProperty("eventHistory")
         await response.data.pipeTo(parser);
 
         // Found N objects


### PR DESCRIPTION
Resolves a general minor issue raised by @danielpeintner in https://github.com/w3c/wot-scripting-api/pull/524#discussion_r1410389930. Maybe we could also consider using one type of quote everywhere, but that could probably be handled automatically by something like prettier.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-scripting-api/pull/525.html" title="Last updated on Nov 30, 2023, 11:06 AM UTC (08f31d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/525/521e7d1...JKRhb:08f31d7.html" title="Last updated on Nov 30, 2023, 11:06 AM UTC (08f31d7)">Diff</a>