### PR TITLE
fix(InteractionOutput): don't require schema.type in value function

### DIFF
--- a/index.html
+++ b/index.html
@@ -1093,7 +1093,7 @@
               steps on |payload| and |subSchema|.
             </li>
             <li>
-              If none or more than two of these runs do not throw, throw
+              If none or more than one of these runs do not throw, throw
               {{TypeError}} and stop.
             </li>
           </ol>

--- a/index.html
+++ b/index.html
@@ -1093,7 +1093,8 @@
               steps on |payload| and |subSchema|.
             </li>
             <li>
-              If all of these runs throw, throw {{TypeError}} and stop.
+              If more than two of these runs do not throw, throw {{TypeError}}
+              and stop.
             </li>
           </ol>
         </li>

--- a/index.html
+++ b/index.html
@@ -1061,13 +1061,6 @@
           If |schema| is `null` or `undefined`, return `undefined`.
         </li>
         <li>
-          <!--
-            TODO: Should we just continue with the rest of the algorithm here?
-          -->
-          If |schema|.|default| is not |undefined| and |payload| is undefined,
-          let |payload| be the value of |schema|.|default|.
-        </li>
-        <li>
           If |schema|.|const| is not |undefined| and |schema|.|const| does not equal |payload|, throw {{TypeError}} and stop.
         </li>
         <li>

--- a/index.html
+++ b/index.html
@@ -976,8 +976,8 @@
         </li>
         <li>
           If |this|.|data| is not a {{ReadableStream}} or if
-          |dataUsed| is `true`, or if |form| is not an {{object}} or if |schema| or its
-          |type| are `null` or `undefined`, then
+          |dataUsed| is `true`, or if |form| is not an {{object}} or if |schema|
+          is `null` or `undefined`, then
           [=reject=] |promise| with {{NotReadableError}} and stop.
         </li>
         <li>

--- a/index.html
+++ b/index.html
@@ -1058,6 +1058,46 @@
       To run the <a>check data schema</a> steps on |payload| and |schema:object|,
       <ol>
         <li>
+          If |schema| is `null` or `undefined`, return `undefined`.
+        </li>
+        <li>
+          <!--
+            TODO: Should we just continue with the rest of the algorithm here?
+          -->
+          If |schema|.|default| is not |undefined| and |payload| is undefined,
+          let |payload| be the value of |schema|.|default|.
+        </li>
+        <li>
+          Let |const| be |schema|.|const|.
+          If |const| is not |undefined|,
+          <ol>
+            <li>
+              <!-- TODO: Should we already return here? -->
+              If |const| equals |payload|, return |payload|.
+            </li>
+            <li>
+              If |const| does not equal |payload|, throw {{TypeError}} and stop.
+            </li>
+          </ol>
+        </li>
+        <li>
+          If |schema|.|enum| is not |undefined| and none of the elements in
+          |schema|.|enum| equal |payload|, throw {{TypeError}} and stop.
+        </li>
+        <li>
+          Let |oneOf| be |schema|.|oneOf|.
+          If |oneOf| is not |undefined|,
+          <ol>
+            <li>
+              For each |subSchema| in |oneOf|, run the <a>check data schema</a>
+              steps on |payload| and |subSchema|.
+            </li>
+            <li>
+              If all of these runs throw, throw {{TypeError}} and stop.
+            </li>
+          </ol>
+        </li>
+        <li>
           Let |type| be |schema|.|type|.
         </li>
         <li>

--- a/index.html
+++ b/index.html
@@ -1068,17 +1068,7 @@
           let |payload| be the value of |schema|.|default|.
         </li>
         <li>
-          Let |const| be |schema|.|const|.
-          If |const| is not |undefined|,
-          <ol>
-            <li>
-              <!-- TODO: Should we already return here? -->
-              If |const| equals |payload|, return |payload|.
-            </li>
-            <li>
-              If |const| does not equal |payload|, throw {{TypeError}} and stop.
-            </li>
-          </ol>
+          If |schema|.|const| is not |undefined| and |schema|.|const| does not equal |payload|, throw {{TypeError}} and stop.
         </li>
         <li>
           If |schema|.|enum| is not |undefined| and none of the elements in

--- a/index.html
+++ b/index.html
@@ -1093,8 +1093,8 @@
               steps on |payload| and |subSchema|.
             </li>
             <li>
-              If more than two of these runs do not throw, throw {{TypeError}}
-              and stop.
+              If none or more than two of these runs do not throw, throw
+              {{TypeError}} and stop.
             </li>
           </ol>
         </li>


### PR DESCRIPTION
At the moment, the `value` function of the `InteractionOutput` interface requires the `type` field of its `schema` to be set. In a discussion over at https://github.com/eclipse-thingweb/node-wot/issues/1221, we identified this as a problem for several different scenarios, including the `exloreDirectory` method, as the `things` property of the Thing Description Directory API specification does not contain a `type` field itself, as there are two different types that can be obtained from the property (namely, an array or an object of TDs).

Therefore, this PR proposes changing the algorithm to not throw anymore when the field should be `null` or `undefined`, making it usable in more scenarios.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-scripting-api/pull/534.html" title="Last updated on Feb 27, 2024, 3:08 PM UTC (b38cf77)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/534/d0c5f8c...JKRhb:b38cf77.html" title="Last updated on Feb 27, 2024, 3:08 PM UTC (b38cf77)">Diff</a>