### PR TITLE
fix: respec warnings about anchor/link

### DIFF
--- a/index.html
+++ b/index.html
@@ -1471,7 +1471,7 @@
     <section>
       <h4>Creating <code>ConsumedThing</code></h4>
       <p>
-        After <a href="#fetching-a-thing-description">fetching</a> a
+        After <a href="#requesting-a-thing-description">requesting</a> a
         <a>Thing Description</a> as a JSON object, one can create a
         {{ConsumedThing}} object.
       </p>
@@ -4295,7 +4295,7 @@
         HTTP client library, which offer already standardized options on
         specifying fetch details.
         In these cases, the user is required to perform validation manually as
-        described by the [[[WoT-TD]]] specification.
+        described by the [[[WOT-TD]]] specification.
       </p>
       <p class="ednote" title="Extending the `requestThingDescription()` method">
         In the future, `requestThingDescription()` might be extended with an


### PR DESCRIPTION
fixes https://github.com/w3c/wot-scripting-api/issues/542


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 502 Bad Gateway :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 1, 2024, 3:33 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdanielpeintner%2Fwot-scripting-api%2F8d34032e01cfa16f813ff02d99aee6147de290ed%2Findex.html%3FisPreview%3Dtrue)

```
error code: 502
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/wot-scripting-api%23543.)._
</details>
