### PR TITLE
feat: expand exploreDirectory algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -754,33 +754,40 @@
           Set |discovery|.{{ThingDiscoveryProcess/[[filter]]}} to |filter:ThingFilter|.
         </li>
         <li>
-          Request the underlying platform to start the directory discovery process.
           <p class="note">
             This is a placeholder for more details in the discovery algorithm.
             Implementations should follow the procedures described in the
             [[wot-discovery]] and [wot-binding-templates] specifications.
-            Some normative steps are indicated below.
+            Some normative steps (that are currently Work in Progress) are
+            indicated below.
           </p>
-          <ol>
-            <li>
-              If |url| is not a <a>TD Directory</a> or if the underlying
-              implementation cannot support the <a>Protocol Binding</a>
-              indicated by |url|, [=reject=] |promise|
-              with {{NotSupportedError}} and terminate these steps.
-            </li>
-            <li>
-              If filters in general are not supported by the implementation and
-              |filter| is not `undefined` or `null`, [=reject=] |promise|
-              with {{NotSupportedError}} and stop.
-            </li>
-            <li>
-              Run the <a>discovery process</a> given |discovery|.
-              <p class="note">
-                From this point on, errors are recorded only on
-                {{ThingDiscoveryProcess/error}}, but don't affect |promise| any longer.
-              </p>
-            </li>
-          </ol>
+
+          If the underlying implementation cannot support the
+          <a>Protocol Binding</a> indicated by |url|, [=reject=] |promise| with
+          {{NotSupportedError}} and stop.
+        </li>
+        <li>
+          Request the underlying platform to retrieve the TD available under
+          |discovery|.{{ThingDiscoveryProcess/[[url]]}}.
+          If that does not return a valid TDD Thing Description, [=reject=]
+          |promise| with {{TypeError}} and stop.
+          <!-- TODO: Define what a valid TDD TD is. -->
+          Otherwise, let |directoryTd| be the retrieved TD.
+        </li>
+        <li>
+          Let |consumedTddThing| be the result of
+          <a href="#creating-consumedthing">creating a <dfn>ConsumedThing</dfn></a>
+          from |directoryTd|.
+          If that fails, resolve |promise| with {{SyntaxError}} and stop.
+        </li>
+        <li>
+          Run the <a>discovery process</a> given |discovery| by
+          either invoking one of the actions associated with the Search API
+          – if the {{ThingDiscoveryProcess/[[filter]]}} argument is not
+          `undefined` or `null` – or reading the `things` property.
+        </li>
+        <li>
+          <!-- TODO: Deal with pagination etc. -->
         </li>
         <li>
           [=Resolve=] |promise| with |discovery|.

--- a/index.html
+++ b/index.html
@@ -731,6 +731,15 @@
             optional ThingFilter filter = {});
       };
     </pre>
+
+    <!-- TODO: Improve and integrate into code section above -->
+    <pre class="idl">
+      dictionary ExploreDirectoryQuery {
+        DOMString query;
+        DOMString queryType;
+      };
+    </pre>
+
     <div>
       Belongs to the <a>WoT Discovery</a> conformance class. Starts the discovery process that given a <a>TD Directory</a> URL, will provide {{ThingDescription}} objects for <a>Thing Description</a>s that match an optional |filter:ThingFilter| argument of type {{ThingFilter}}. The method MUST run the following steps:
       <ol>
@@ -3861,7 +3870,8 @@
       <pre class="idl">
         dictionary ThingFilter {
           object? fragment;
-          <!-- DOMString? query; -->
+          <!-- TODO: Should this be part of the general "ThingFilter"? -->
+          ExploreDirectoryQuery? directoryQuery
         };
       </pre>
       <p>

--- a/index.html
+++ b/index.html
@@ -790,13 +790,24 @@
           If that fails, resolve |promise| with {{SyntaxError}} and stop.
         </li>
         <li>
-          Run the <a>discovery process</a> given |discovery| by
-          either invoking one of the actions associated with the Search API
-          – if the {{ThingDiscoveryProcess/[[filter]]}} argument is not
-          `undefined` or `null` – or reading the `things` property.
-        </li>
-        <li>
-          <!-- TODO: Deal with pagination etc. -->
+          Run the <a>discovery process</a> given |discovery| by running the
+          following steps:
+          <ol>
+            <!-- TODO: Deal with pagination etc. -->
+            <li>
+              If the {{ThingDiscoveryProcess/[[filter]]}} argument is not
+              `undefined` or `null`, invoke the Action that represents the
+              corresponding Search API.
+              <!--
+                TODO: Specify a mapping of filter values to search API actions
+              -->
+              If the corresponding Action is not present, throw a
+              {{NotSupportedError}} and stop.
+            </li>
+            <li>
+              Otherwise, read the `things` property.
+            </li>
+          </ol>
         </li>
         <li>
           [=Resolve=] |promise| with |discovery|.

--- a/index.html
+++ b/index.html
@@ -796,8 +796,10 @@
             <!-- TODO: Deal with pagination etc. -->
             <li>
               If the {{ThingDiscoveryProcess/[[filter]]}} argument is not
-              `undefined` or `null`, invoke the Action that represents the
-              corresponding Search API.
+              `undefined` or `null`, let |queryType| be invoke the Action that
+              represents the corresponding Search API described by
+              <!-- TODO: Check syntax and field access. -->
+              {{ThingDiscoveryProcess/[[filter]].queryType}}.
               <!--
                 TODO: Specify a mapping of filter values to search API actions
               -->


### PR DESCRIPTION
This PR contains a rough first draft for expanding the `exploreDirectory` algorithm.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-scripting-api/pull/545.html" title="Last updated on Jul 8, 2024, 9:03 AM UTC (dc81bc5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/545/352fe0c...JKRhb:dc81bc5.html" title="Last updated on Jul 8, 2024, 9:03 AM UTC (dc81bc5)">Diff</a>