### PR TITLE
Eclipse Thingweb links fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,8 +186,8 @@
       The APIs defined in this document deliberately follow the [[[WOT-TD]]] specification closely. It is possible to implement more abstract APIs on top of them, or implementing directly the WoT network facing interface (i.e. the <a>WoT Interface</a>).
     </p>
     <p class="ednote">
-      This specification is implemented at least by the <a href="http://www.thingweb.io/">Eclipse Thingweb</a>
-      project also known as <a href="https://github.com/eclipse/thingweb.node-wot">node-wot</a>, which is considered the reference open source implementation at the moment. Check its <a href="https://github.com/eclipse/thingweb.node-wot"> source code</a>, including <a href="https://github.com/eclipse/thingweb.node-wot/tree/master/examples">examples</a>.
+      This specification is implemented at least by the <a href="https://www.thingweb.io/">Eclipse Thingweb</a>
+      project also known as <a href="https://github.com/eclipse-thingweb/node-wot">node-wot</a>, which is considered the reference open source implementation at the moment. Check its <a href="https://github.com/eclipse-thingweb/node-wot"> source code</a>, including <a href="https://github.com/eclipse-thingweb/node-wot/tree/master/examples">examples</a>.
     </p>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -4273,8 +4273,8 @@
           some challenges, this specification takes another approach that
           exposes software objects to represent the <a>Thing</a> metadata as
           data property and the WoT interactions as methods. One implementation
-          is <a href="https://github.com/eclipse/thingweb.node-wot">node-wot</a>
-          in the <a href="http://www.thingweb.io/">Eclipse ThingWeb</a> project,
+          is <a href="https://github.com/eclipse-thingweb/node-wot">node-wot</a>
+          in the <a href="https://www.thingweb.io/">Eclipse ThingWeb</a> project,
           which is the current reference implementation of the API specified in
           this document.
         </p>


### PR DESCRIPTION
The project has a new GitHub organization now and https webpage instead of http


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/pull/549.html" title="Last updated on Apr 29, 2024, 1:28 PM UTC (6334fc0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/549/ab7cd69...6334fc0.html" title="Last updated on Apr 29, 2024, 1:28 PM UTC (6334fc0)">Diff</a>