### PR TITLE
Add clarifications for `discover` method

### DIFF
--- a/index.html
+++ b/index.html
@@ -757,6 +757,15 @@
           [=Resolve=] |promise| with |discovery|.
         </li>
       </ol>
+      <p>
+        Note that the details of the <a>discovery process</a> depend on the
+        underlying implementation which needs to be preconfigured in order to
+        use, for example, the appropriate Introduction methods as defined in
+        the [[[wot-discovery]]] specification.
+        Since the <code>discover()</code> method outputs
+        <a>Thing Description</a>s and not URLs, it is expected to cover both the
+        Introduction and the Exploration phase.
+      </p>
     </div>
   </section>
 


### PR DESCRIPTION
After the discussions we had on Monday, I dealt a little more with the usage of the `discover` method and I realized that we are actually in quite a good shape there already if we simply keep the method generic and let the underlying implementation handle the details of how the discovery is supposed to be performed.

However, in order to make it a bit clearer, how the `discover` method relates to the concepts of introduction and exploration from the discovery specification, this PR adds an explanatory paragraph after the main discover algorithm. With that in place, we could simply let implementors add ways to configure their respective platform (e.g., the `Servient` class in the case of `node-wot`) to use the right mechanism for the job.

Besides that, this PR also makes some minor changes to the `ThingDiscoveryProcess` interface, as it is supposed to have a `url` field which is, however, only used by the `exploreDirectory` method. Maybe we could consider defining more specialized interfaces for the two methods at some point.

Lastly, this PR also made me wonder whether we should use a TD instead of a URL as the parameter type of the `exploreDirectory` method, as otherwise it slightly more difficult to pipe in the (filtered) results from the `discover` method if a user should want to do that. We could of course also consider that the `discover` method handles directory exploration, but that might give away too much control from the user. The approach that gives the most amount of control would probably be letting the `discover` method return URLs, but especially in the context of the discussion we had in #535, this might not be desirable here.

Looking forward to your thoughts and the review of this PR :)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-scripting-api/pull/551.html" title="Last updated on Jul 8, 2024, 7:42 AM UTC (09bee91)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/551/23dc59e...JKRhb:09bee91.html" title="Last updated on Jul 8, 2024, 7:42 AM UTC (09bee91)">Diff</a>