### PR TITLE
chore: enable dark mode support

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta name="color-scheme" content="light dark" />
     <title>Web of Things (WoT) Scripting API</title>
     <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove' defer></script>
     <script class='remove'>


### PR DESCRIPTION
As discussed in https://github.com/w3c/wot-thing-description/pull/2029, this simply also enables dark mode support for this repository.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-scripting-api/pull/556.html" title="Last updated on Jul 8, 2024, 8:30 AM UTC (bf90f2e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/556/352fe0c...JKRhb:bf90f2e.html" title="Last updated on Jul 8, 2024, 8:30 AM UTC (bf90f2e)">Diff</a>