### PR TITLE
fix(ThingDiscoveryProcess): clarify usage of url field

### DIFF
--- a/index.html
+++ b/index.html
@@ -3776,7 +3776,7 @@
     <pre class="idl">
       [SecureContext, Exposed=(Window,Worker)]
       interface ThingDiscoveryProcess {
-        constructor(optional ThingFilter filter = {}, optional URL url);
+        constructor(optional ThingFilter filter = {});
         readonly attribute boolean done;
         readonly attribute Error? error;
         undefined stop();
@@ -3803,7 +3803,7 @@
       <tr>
         <td><dfn>[[\url]]</dfn></td>
         <td>`undefined`</td>
-        <td>A {{URL}} representing the <a>TD Directory</a> when instantiated by the <code>exploreDirectory()</code> method.</td>
+        <td>A {{URL}} representing the <a>TD Directory</a> when used within the `exploreDirectory()` method.</td>
       </tr>
       </tbody>
     </table>

--- a/index.html
+++ b/index.html
@@ -3776,7 +3776,7 @@
     <pre class="idl">
       [SecureContext, Exposed=(Window,Worker)]
       interface ThingDiscoveryProcess {
-        constructor(optional ThingFilter filter = {});
+        constructor(optional ThingFilter filter = {}, optional URL url);
         readonly attribute boolean done;
         readonly attribute Error? error;
         undefined stop();
@@ -3803,7 +3803,7 @@
       <tr>
         <td><dfn>[[\url]]</dfn></td>
         <td>`undefined`</td>
-        <td>A {{URL}} representing the <a>TD Directory</a> in a discovery.</td>
+        <td>A {{URL}} representing the <a>TD Directory</a> when instantiated by the <code>exploreDirectory()</code> method.</td>
       </tr>
       </tbody>
     </table>


### PR DESCRIPTION
This PR takes over the commit discussed under https://github.com/w3c/wot-scripting-api/pull/551#discussion_r1632756745. However, I already adjusted it insofar that I removed the adjustments of the constructor, not adding an optional `url` parameter.

However, since the field is set "externally" in the current `exploreDirectory` algorithm, I think it would still make sense to adjust the data structure here to make it "less mutable" if not immutable if possible. If I see it correctly, one way to achieve this in WebIDL could be defining a [second constructor](https://webidl.spec.whatwg.org/#idl-constructors) with a mandatory URL parameter. Maybe this something we could discuss in today's call.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-scripting-api/pull/557.html" title="Last updated on Jul 8, 2024, 8:43 AM UTC (dddb6ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/557/352fe0c...JKRhb:dddb6ce.html" title="Last updated on Jul 8, 2024, 8:43 AM UTC (dddb6ce)">Diff</a>