### PR TITLE
increase scripting version to SNAPSHOT.31

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -549,7 +549,7 @@
     },
     "scripting-api": {
       "name": "wot-typescript-definitions",
-      "version": "0.8.0-SNAPSHOT.30",
+      "version": "0.8.0-SNAPSHOT.31",
       "license": "W3C-20150513",
       "dependencies": {
         "wot-thing-description-types": "1.1.0-12-March-2025"

--- a/typescript/scripting-api/package.json
+++ b/typescript/scripting-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wot-typescript-definitions",
-  "version": "0.8.0-SNAPSHOT.30",
+  "version": "0.8.0-SNAPSHOT.31",
   "description": "TypeScript definitions for the W3C WoT Scripting API",
   "author": "W3C Web of Things Working Group",
   "license": "W3C-20150513",


### PR DESCRIPTION
To be able to experiment with https://github.com/w3c/wot-scripting-api/pull/561 we should increase and publish version on NPM

TODO after approved it should be published on NPM.