### PR TITLE
Change return type of invokeAction from InteractionOutput to ActionInteractionOutput

### DIFF
--- a/index.html
+++ b/index.html
@@ -2040,7 +2040,7 @@
         Takes as arguments |actionName:string|, optionally
         |params:InteractionInput| and optionally |options:InteractionOptions|.
         It returns a {{Promise}} that resolves with the result of the <a>Action</a>
-        represented as an {{InteractionOutput}} object, or rejects with an error.
+        represented as an {{ActionInteractionOutput}} object, or rejects with an error.
         The method MUST run the following steps:
         <ol>
           <li>


### PR DESCRIPTION
follow-up for https://github.com/w3c/wot-scripting-api/pull/561


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-scripting-api/pull/580.html" title="Last updated on Oct 29, 2025, 2:34 PM UTC (01431ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/580/5a47913...danielpeintner:01431ac.html" title="Last updated on Oct 29, 2025, 2:34 PM UTC (01431ac)">Diff</a>