### PR TITLE
refactor: move Zoltan to former editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,9 +24,9 @@
         noIDLIn:              true,
         noRecTrack:           true,
         editors: [
-          { name: "Zoltan Kis", w3cid: "57789", company: "Intel Corp.", companyURL: "https://www.intel.com/" },
           { name: "Daniel Peintner", w3cid: "39497", company: "Siemens AG", companyURL: "https://www.siemens.com/" },
           { name: "Cristiano Aguzzi", w3cid: "105495", company: "Invited Expert", companyURL: "https://github.com/relu91" },
+          { name: "Zoltan Kis", w3cid: "57789", note: "Former Editor, when at Intel Corp." },
           { name: "Johannes Hund", w3cid: "74472", note: "Former Editor, when at Siemens AG" },
           { name: "Kazuaki Nimura", w3cid: "59208", note: "Former Editor, at Fujitsu Ltd." },
         ],

--- a/index.html
+++ b/index.html
@@ -25,10 +25,12 @@
         noRecTrack:           true,
         editors: [
           { name: "Daniel Peintner", w3cid: "39497", company: "Siemens AG", companyURL: "https://www.siemens.com/" },
-          { name: "Cristiano Aguzzi", w3cid: "105495", company: "Invited Expert", companyURL: "https://github.com/relu91" },
-          { name: "Zoltan Kis", w3cid: "57789", note: "Former Editor, when at Intel Corp." },
-          { name: "Johannes Hund", w3cid: "74472", note: "Former Editor, when at Siemens AG" },
-          { name: "Kazuaki Nimura", w3cid: "59208", note: "Former Editor, at Fujitsu Ltd." },
+          { name: "Cristiano Aguzzi", w3cid: "105495", company: "Invited Expert", companyURL: "https://github.com/relu91" }
+        ],
+        formerEditors: [
+          { name: "Zoltan Kis", w3cid: "57789", note: "while at Intel Corp." },
+          { name: "Johannes Hund", w3cid: "74472", note: "while at Siemens AG" },
+          { name: "Kazuaki Nimura", w3cid: "59208", note: "while at Fujitsu Ltd." }
         ],
         otherLinks: [
           {


### PR DESCRIPTION
I moved to @zolkis  to former editor

I have 2 questions:
* is there any specific order of the list we need to respect?
* for Nimura-San ) (@knimura) … add "when" at Fujitsu Ltd. also? I think he is no longer with Fujitsu?


resolves https://github.com/w3c/wot-scripting-api/issues/583


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-scripting-api/pull/584.html" title="Last updated on Feb 17, 2026, 3:27 PM UTC (da255ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/584/5e16f9c...danielpeintner:da255ae.html" title="Last updated on Feb 17, 2026, 3:27 PM UTC (da255ae)">Diff</a>