### PR TITLE
feat: handle interaction error response algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -1437,6 +1437,10 @@
 
     <section data-dfn-for="InteractionError">
       <h3>The <dfn>InteractionError</dfn> interface</h3>
+      <p class="note">
+        Currently, we are looking for wider implementation of the following section. 
+        The alorithm presented here might be subject to changes in the future. 
+      </p>
       <p>
         Represents an error that occurred during a <a>WoT Interaction</a> with
         additional diagnostic information from the <a>Thing</a> in the form of
@@ -1518,16 +1522,6 @@
         </li>
       </ol>
     </section>
-
-    <p class="ednote">
-      This topic is still being discussed in
-      <a href="https://github.com/w3c/wot-scripting-api/issues/200">Issue #200</a>.
-      A standardized error mapping would be needed in order to ensure consistency
-      in mapping script errors to protocol errors and vice versa. In particular,
-      when algorithms say "error received from the <a>Protocol Bindings</a>",
-      that will be factored out as an explicit error mapping algorithm. Currently,
-      that is encapsulated by implementations.
-    </p>
   </section>
 
   </section> <!-- Handling interaction data -->

--- a/index.html
+++ b/index.html
@@ -1779,10 +1779,25 @@
             Let |result:object| be an object and for each string |name:string| in |propertyNames| add a property with key |name| and the value `null`.
           </li>
           <li>
+            If this cannot be done with a single request with the <a>Protocol Bindings</a>, [=reject=] |promise| with a
+            {{NotSupportedError}} and stop.
+          </li>
+          <li>
             Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to retrieve the <a>Property</a> values given by |propertyNames| with |form| and optional URI templates given in |options|' |uriVariables|.
           </li>
           <li>
-            If this cannot be done with a single request with the <a>Protocol Bindings</a>, [=reject=] |promise| with a {{NotSupportedError}} and stop.
+            If the request fails with error |receivedError| and optionally |failedResponse|,
+            run the following sub-steps:
+            <ol>
+              <li>
+                let |error| be the result of running
+                <a>handle interaction error response</a> given the |receivedError|
+                |form| and |failedResponse|.
+              </li>
+              <li>
+                [=Reject=] |promise| with |error| and stop.
+              </li>
+            </ol>
           </li>
           <li>
             Process the response and for each |key| in |result|, run the following
@@ -1850,7 +1865,18 @@
             If this cannot be done with a single request with the <a>Protocol Bindings</a> of the <a>Thing</a>, then [=reject=] |promise| with a {{NotSupportedError}} and stop.
           </li>
           <li>
-            If the request fails, [=reject=] |promise| with the error received from the <a>Protocol Bindings</a> and stop.
+            If the request fails with error |receivedError| and optionally |failedResponse|,
+            run the following sub-steps:
+            <ol>
+              <li>
+                let |error| be the result of running
+                <a>handle interaction error response</a> given the |receivedError|
+                |form| and |failedResponse|.
+              </li>
+              <li>
+                [=Reject=] |promise| with |error| and stop.
+              </li>
+            </ol>
           </li>
           <li>
             Process the reply and let |result:object| be an object with the keys and values obtained in the reply.
@@ -1920,7 +1946,18 @@
             |options|' |uriVariables|.
           </li>
           <li>
-            If the request fails, [=reject=] |promise| with the error received from the <a>Protocol Bindings</a> and stop.
+            If the request fails with error |receivedError| and optionally |failedResponse|,
+            run the following sub-steps:
+            <ol>
+              <li>
+                let |error| be the result of running
+                <a>handle interaction error response</a> given the |receivedError|
+                |form| and |failedResponse|.
+              </li>
+              <li>
+                [=Reject=] |promise| with |error| and stop.
+              </li>
+            </ol>
           </li>
           <li>
             Otherwise [=resolve=] |promise|.
@@ -2004,8 +2041,18 @@
             with a {{NotSupportedError}} and stop.
           </li>
           <li>
-            If the request fails, return the error received from the
-            <a>Protocol Bindings</a> and stop.
+            If the request fails with error |receivedError| and optionally |failedResponse|,
+            run the following sub-steps:
+            <ol>
+              <li>
+                let |error| be the result of running
+                <a>handle interaction error response</a> given the |receivedError|
+                |form| and |failedResponse|.
+              </li>
+              <li>
+                [=Reject=] |promise| with |error| and stop.
+              </li>
+            </ol>
           </li>
           <li>
             Otherwise [=resolve=] |promise|.
@@ -2093,8 +2140,18 @@
             optional URI templates given in |options|' |uriVariables|.
           </li>
           <li>
-            If the request fails, [=reject=] |promise| with the error received from
-            the <a>Protocol Bindings</a> and stop.
+            If the request fails with error |receivedError| and optionally |failedResponse|,
+            run the following sub-steps:
+            <ol>
+              <li>
+                let |error| be the result of running
+                <a>handle interaction error response</a> given the |receivedError|
+                |form| and |failedResponse|.
+              </li>
+              <li>
+                [=Reject=] |promise| with |error| and stop.
+              </li>
+            </ol>
           </li>
           <li>
             [=map/Set=] |thing|.{{ConsumedThing/[[activeObservations]]}}[|propertyName] to |subscription| and [=resolve=] |promise|.
@@ -2183,7 +2240,18 @@
             Make a request to the underlying platform (via the <a>Protocol Bindings</a>) to invoke the <a>Action</a> identified by |actionName| given |args| and |options|.|uriVariables|.
           </li>
           <li>
-            If the request fails locally or returns an error over the network, [=reject=] |promise| with the error received from the <a>Protocol Bindings</a> and stop.
+            If the request fails with error |receivedError| and optionally |failedResponse|,
+            run the following sub-steps:
+            <ol>
+              <li>
+                let |error| be the result of running
+                <a>handle interaction error response</a> given the |receivedError|
+                |form| and |failedResponse|.
+              </li>
+              <li>
+                [=Reject=] |promise| with |error| and stop.
+              </li>
+            </ol>
           </li>
           <li>
             Let |value| be the reply returned in the reply.
@@ -2272,8 +2340,18 @@
             and optional subscription data given in |options|.|data|.
           </li>
           <li>
-            If the request fails, [=reject=] |promise| with the error received from
-            the <a>Protocol Bindings</a> and stop.
+            If the request fails with error |receivedError| and optionally |failedResponse|,
+            run the following sub-steps:
+            <ol>
+              <li>
+                let |error| be the result of running
+                <a>handle interaction error response</a> given the |receivedError|
+                {{Subscription/[[form]]}} and |failedResponse|.
+              </li>
+              <li>
+                [=Reject=] |promise| with |error| and stop.
+              </li>
+            </ol>
           </li>
           <li>
             [=map/Set=] |eventName| to |thing|.{{ConsumedThing/[[activeSubscriptions]]}}[|eventName|] to |subscription|.
@@ -2489,8 +2567,22 @@
               unsubscribe data given in |options|.|data|.
             </li>
             <li>
-              If the request fails, [=reject=] |promise| with the error received from
-              the <a>Protocol Bindings</a> and stop.
+              If the request fails with error |receivedError| and optionally |failedResponse|,
+              run the following sub-steps:
+              <ol>
+                <li>
+                  let |error| be the result of running
+                  <a>handle interaction error response</a> given the |receivedError|
+                  |unsubscribeForm| and |failedResponse|.
+                </li>
+                <li>
+                  [=Reject=] |promise| with |error| and stop.
+                </li>
+                <li>
+                  If the underlying platform receives further notifications for this
+                  subscription, implementations SHOULD silently suppress them.
+                </li>
+              </ol>
             </li>
             <li>
               Otherwise:

--- a/index.html
+++ b/index.html
@@ -355,7 +355,7 @@
       The generic WoT terminology is defined in [[!wot-architecture11]]: <dfn data-lt="Things">Thing</dfn>, <dfn data-lt="Thing Descriptions">Thing Description</dfn> (in short <dfn>TD</dfn>), <dfn>Partial TD</dfn>, <dfn>Web of Things</dfn> (in short <b><i>WoT</i></b>),  <dfn>WoT Interface</dfn>, <dfn>Protocol Bindings</dfn>, <dfn>WoT Runtime</dfn>, <dfn data-lt="consume|consume a TD|consuming a TD">Consuming a Thing Description</dfn>, <dfn>TD Directory</dfn>, <dfn data-lt="Properties">Property</dfn>, <dfn data-lt="Actions">Action</dfn>, <dfn data-lt="Events|WoT-Event">Event</dfn>,
       <a data-cite="wot-thing-description11#dataschema">
         <dfn>DataSchema</dfn></a>, <a data-cite="wot-thing-description11#form"><dfn data-lt="Forms">Form</dfn></a>,
-        <a data-cite="wot-thing-description11#securityscheme"><dfn>SecurityScheme</dfn></a>, <a data-cite="wot-thing-description11#nosecurityscheme"><dfn>NoSecurityScheme</dfn></a> etc.
+        <a data-cite="wot-thing-description11#securityscheme"><dfn>SecurityScheme</dfn></a>, <a data-cite="wot-thing-description11#nosecurityscheme"><dfn>NoSecurityScheme</dfn></a>, <a data-cite="wot-thing-description11#additionalexpectedresponse"><dfn>AdditionalExpectedResponse</dfn></a> etc.
     </p>
     <p>
       <dfn data-plurals="WoT Interactions">WoT Interaction</dfn> is a synonym for <a data-cite="wot-architecture11#dfn-interaction-affordance"><dfn>Interaction Affordance</dfn></a>.
@@ -365,6 +365,10 @@
       However, this term is not well understood outside the <a>TD</a> semantic context.
       Hence for the sake of readability, this document will use the previous term
       <a>WoT interaction</a> or, simply, <em>interaction</em> instead.
+    </p>
+    <p>
+      <dfn data-plurals="interaction methods">interaction method</dfn> indicate one of the method defined in the {{ConsumedThing}} interface
+      to interact with a <a>Thing</a> (e.g. <code>readProperty()</code>, <code>writeProperty()</code>, <code>invokeAction()</code>, etc.).
     </p>
     <p>
       <dfn>WoT network interface</dfn> synonym for <a>WoT Interface</a>.
@@ -1434,6 +1438,91 @@
                 title="Error handling"/>
       <figcaption>Error handling in WoT interactions</figcaption>
     </figure>
+
+    <section data-dfn-for="InteractionError">
+      <h3>The <dfn>InteractionError</dfn> interface</h3>
+      <p>
+        Represents an error that occurred during a <a>WoT Interaction</a> with
+        additional diagnostic information from the <a>Thing</a> in the form of
+        response data associated with an <a>AdditionalExpectedResponse</a> defined in
+        the <a>Thing Description</a>.
+      </p>
+      <pre class="idl">
+        [SecureContext, Exposed=(Window,Worker)]
+        interface InteractionError : Error {
+          constructor(DOMString message, InteractionOutput data);
+          readonly attribute InteractionOutput data;
+        };
+      </pre>
+      <p>
+        The <dfn data-lt="InteractionError.data">data</dfn> attribute represents
+        the {{InteractionOutput}} object containing the response payload from the 
+        failed <a>WoT Interaction</a>.
+      </p>
+    </section>
+
+    <section>
+      <h3>The <dfn>handle interaction error response</dfn> algorithm</h3>
+      <p>
+        This algorithm is used by <a>interaction methods</a> to process error responses
+        from the <a>Protocol Bindings</a> and determine whether to create an
+        {{InteractionError}} or map to a standard error type.
+      </p>
+      <p>
+        To <a>handle interaction error response</a> given   |error|, |form:Form| and |response|, 
+        run these steps:
+      </p>
+      <ol>
+        <li>
+          if |response| is not defined or null, attempt to map |error|
+          to a suitable {{DOMException}} or, if none, to {{OperationError}}. 
+          Return that error and stop.
+        </li>
+        <li>
+          Let |additionalResponses| be |form|.|additionalResponses|, if it exists.
+        </li>
+        <li>
+          Let |binding| be the binding that was used to make the request which resulted in |response|.
+        </li>
+        <li>
+          If |additionalResponses| is defined, for each |responseEntry:AdditionalExpectedResponse| in
+          |additionalResponses|:
+          <ol>
+            <li>
+              Let |match| be a boolean expression that checks if |response| matches a |responseEntry| according to |binding|
+            </li>
+            <li>
+              If |responseEntry|.|success| is `false` or not defined and if |match| is `true` for |responseEntry|, 
+              then run these sub-steps:
+              <ol>
+                <li>
+                  Let |responseSchema| be |responseEntry|.|schema|, if it exists.
+                </li>
+                <li>
+                  Let |errorOutput:InteractionOutput| be the result of running
+                  <a>parse interaction response</a> on |response|, |form|, and
+                  |responseSchema|.
+                </li>
+                <li>
+                  Return a new {{InteractionError}} constructed with |errorOutput| an appropriate
+                  message derived from the |binding| or |error|.
+                </li>
+              </ol>
+            </li>
+          </ol>
+        </li>
+        <li>
+          If no match was found in |additionalResponses| but |binding| indicates
+          a failure, attempt to map the error
+          to a suitable {{DOMException}} or other appropriate
+          error type.
+        </li>
+        <li>
+          Otherwise, return {{OperationError}}.
+        </li>
+      </ol>
+    </section>
+
     <p class="ednote">
       This topic is still being discussed in
       <a href="https://github.com/w3c/wot-scripting-api/issues/200">Issue #200</a>.
@@ -1635,7 +1724,18 @@
             using |form| and the optional URI templates given in |options|.|uriVariables|.
           </li>
           <li>
-            If the request fails, [=reject=] |promise| with the error received from the <a>Protocol Bindings</a> and stop.
+            If the request fails with error |receivedError| and optionally |failedResponse|, 
+            run the followingsub-steps:
+            <ol>
+              <li>
+                let |error| be the result of running
+                <a>handle interaction error response</a> given the |receivedError|
+                |form| and |failedResponse|.
+              </li>
+              <li>
+                [=Reject=] |promise| with |error| and stop.
+              </li>
+            </ol>
           </li>
           <li>
             Let |response| be the response received to the request.

--- a/index.html
+++ b/index.html
@@ -367,10 +367,6 @@
       <a>WoT interaction</a> or, simply, <em>interaction</em> instead.
     </p>
     <p>
-      <dfn data-plurals="interaction methods">interaction method</dfn> indicate one of the method defined in the {{ConsumedThing}} interface
-      to interact with a <a>Thing</a> (e.g. <code>readProperty()</code>, <code>writeProperty()</code>, <code>invokeAction()</code>, etc.).
-    </p>
-    <p>
       <dfn>WoT network interface</dfn> synonym for <a>WoT Interface</a>.
     </p>
     <p>
@@ -1464,9 +1460,9 @@
     <section>
       <h3>The <dfn>handle interaction error response</dfn> algorithm</h3>
       <p>
-        This algorithm is used by <a>interaction methods</a> to process error responses
-        from the <a>Protocol Bindings</a> and determine whether to create an
-        {{InteractionError}} or map to a standard error type.
+        This algorithm is invoked by any {{ConsumedThing}} method that performs a <a>WoT Interaction</a>.
+        It processes error responses returned by the <a>Protocol Bindings</a> and determines whether to
+        throw an {{InteractionError}} or map the response to a {{DOMException}}.
       </p>
       <p>
         To <a>handle interaction error response</a> given   |error|, |form:Form| and |response|, 

--- a/index.html
+++ b/index.html
@@ -1439,7 +1439,7 @@
       <h3>The <dfn>InteractionError</dfn> interface</h3>
       <p class="note">
         Currently, we are looking for wider implementation of the following section. 
-        The alorithm presented here might be subject to changes in the future. 
+        The algorithm presented here might be subject to changes in the future. 
       </p>
       <p>
         Represents an error that occurred during a <a>WoT Interaction</a> with
@@ -1504,8 +1504,9 @@
                   |responseSchema|.
                 </li>
                 <li>
-                  Return a new {{InteractionError}} constructed with |errorOutput| an appropriate
-                  message derived from the |binding| or |error|.
+                  Return a newly constructed {{InteractionError}}, using a message
+                  derived from the |binding| or |error| as first argument, and |errorOutput| 
+                  as second argument.
                 </li>
               </ol>
             </li>


### PR DESCRIPTION
Initial draft of the algorithm to handle interaction error response, as described in issue #560. 

Discussions points:
- Introduced the concept of `interaction method` to indicate one of the methods of Consumed thing that implements a TD operation. 
- The mapping between `AdditionalExpectedResponse` and the actual response is left underspicified to let the protocol binding implementation decide (for example, the HTTP binding might use `htv:statusCodeValue` to match the right expected response)
- I introduced a dedicated custom error for error responses that match the one declared in the TD. OperationError in the end was too generic, and it didn't allow attaching the response as `InteractionOutput` as I did with `InteractionError`
- Given the fact that `InteractionOuput` take as input a Form we should override its content-type with the one declared in the `AdditionalExpectedResponse`. This change is not yet in this PR.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/relu91/wot-scripting-api/pull/589.html" title="Last updated on May 13, 2026, 1:28 PM UTC (0b8567d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/589/10f56f0...relu91:0b8567d.html" title="Last updated on May 13, 2026, 1:28 PM UTC (0b8567d)">Diff</a>