### PR TITLE
Clarify the role of URI variables in observe and subscribe ops

### DIFF
--- a/index.html
+++ b/index.html
@@ -1538,14 +1538,18 @@
           <td><dfn>[[\activeSubscriptions]]</dfn></td>
           <td>`{}`</td>
           <td>
-            An [=ordered map=] [=map/keyed=] on a [=string=] name representing the <a>Event</a> and [=map/value=] is a {{Subscription}} object.
+            An [=ordered map=] [=map/keyed=] on a <a>subscription identifier</a>
+            derived from the <a>Event</a> name, and [=map/value=] is a
+            {{Subscription}} object.
           </td>
         </tr>
         <tr>
           <td><dfn>[[\activeObservations]]</dfn></td>
           <td>`{}`</td>
           <td>
-            An [=ordered map=] [=map/keyed=] on a [=string=] name representing a <a>Property</a> and [=map/value=] is a {{Subscription}} object.
+            An [=ordered map=] [=map/keyed=] on a <a>subscription identifier</a>
+            derived from the <a>Property</a> name, and [=map/value=] is a
+            {{Subscription}} object.
           </td>
         </tr>
         </tbody>
@@ -1915,6 +1919,64 @@
     </section>
 
     <section>
+      <h3>The <dfn data-lt="subscription identifier">create a subscription identifier</dfn> algorithm</h3>
+      <div>
+        A single <a>Property</a> or <a>Event</a> can be the target of several
+        active {{Subscription}}s at the same time, as long as they are made
+        with different URI variables. To distinguish between them, a
+        <a>subscription identifier</a> is used as the key of the
+        {{ConsumedThing/[[activeObservations]]}} and
+        {{ConsumedThing/[[activeSubscriptions]]}} internal slots instead of
+        plainly using the <a>Property</a> or <a>Event</a> name.
+        <p>
+          To <a>create a subscription identifier</a> given |name:string| and
+          |options:InteractionOptions|, run the following steps:
+        </p>
+        <ol>
+          <li>
+            Let |identifier| be |name|.
+          </li>
+          <li>
+            If |options|.|uriVariables| [=map/exists=], then:
+            <ol>
+              <li>
+                Let |keys| be the result of getting the keys of
+                |options|.|uriVariables|, sorted in ascending code point
+                order.
+              </li>
+              <li>
+                For each |key| in |keys|, set |identifier| to the
+                concatenation of |identifier|, `"&"`, |key|, `"="`, and the
+                result of running <a data-cite=
+                "infra#serialize-a-javascript-value-to-a-json-string">
+                serialize a JavaScript value to a JSON string</a> on
+                |options|.|uriVariables|[|key|].
+              </li>
+            </ol>
+          </li>
+          <li>
+            Return |identifier|.
+          </li>
+        </ol>
+        <p class="note">
+          <a>Protocol Bindings</a> MAY apply their own, more elaborate,
+          rationale for deciding whether two requests represent distinct
+          subscriptions. At the time of writing, [[!wot-thing-description11]]
+          only allows a client to distinguish requests to observe a
+          <a>Property</a> by their URI variables, and requests to subscribe to
+          an <a>Event</a> by their URI variables and subscription data;
+          implementations are therefore not expected to need anything more
+          elaborate than the algorithm above. Regardless of the algorithm
+          used, an implementation MUST NOT multiplex several {{Subscription}}s
+          (e.g., several listener functions) onto a single underlying
+          protocol-level subscription: every active {{Subscription}} is
+          expected to correspond to its own request to, and its own
+          notifications from, the underlying platform.
+        </p>
+      </div>
+    </section>
+
+    <section>
       <h3>The <dfn>observeProperty()</dfn> method</h3>
       <div>
         Makes a request for <a>Property</a> value change notifications.
@@ -1922,9 +1984,12 @@
         optionally |onerror:ErrorListener| and |options:InteractionOptions|.
         It returns a {{Promise}} that resolves on success and rejects on failure.
         <p class="ednote">
-          This algorithm allows for only one active {{Subscription}} per <a>Property</a>. If a new
-          {{Subscription}} is made while an existing {{Subscription}} is active the runtime
-          will throw an {{NotAllowedError}}.
+          This algorithm allows for only one active {{Subscription}} per
+          <a>Property</a> and <a>subscription identifier</a> (i.e., per
+          combination of URI variables used to observe the <a>Property</a>).
+          If a new {{Subscription}} is made with the same <a>Property</a> and
+          the same URI variables while an existing {{Subscription}} is active,
+          the runtime will throw an {{NotAllowedError}}.
         </p>
         The method MUST run the following steps:
         <ol>
@@ -1946,7 +2011,12 @@
             with a {{TypeError}} and stop.
           </li>
           <li>
-            If |thing|.{{ConsumedThing/[[activeObservations]]}}[|propertyName|] [=map/exists=], [=reject=] |promise| with a {{NotAllowedError}} and stop.
+            Let |observationId| be the result of running the
+            <a>create a subscription identifier</a> steps given |propertyName|
+            and |options|.
+          </li>
+          <li>
+            If |thing|.{{ConsumedThing/[[activeObservations]]}}[|observationId|] [=map/exists=], [=reject=] |promise| with a {{NotAllowedError}} and stop.
           </li>
           <li>
             Let |subscription| be a new {{Subscription}} object with its <a>internal slots</a>
@@ -1957,6 +2027,9 @@
               </li>
               <li>
                 Let |subscription|.{{Subscription/[[name]]}} be |propertyName|.
+              </li>
+              <li>
+                Let |subscription|.{{Subscription/[[identifier]]}} be |observationId|.
               </li>
               <li>
                 Let |subscription|.{{Subscription/[[interaction]]}} be  {{ConsumedThing/[[td]]}}.|properties|[|propertyName|].
@@ -1997,11 +2070,11 @@
             the <a>Protocol Bindings</a> and stop.
           </li>
           <li>
-            [=map/Set=] |thing|.{{ConsumedThing/[[activeObservations]]}}[|propertyName] to |subscription| and [=resolve=] |promise|.
+            [=map/Set=] |thing|.{{ConsumedThing/[[activeObservations]]}}[|observationId|] to |subscription| and [=resolve=] |promise|.
           </li>
           <li>
             Whenever the underlying platform detects a notification for this
-            |subscription| [=map/keyed=] on |propertyName| with a new <a>Property</a> value |value|,
+            |subscription| [=map/keyed=] on |observationId| with a new <a>Property</a> value |value|,
             run the following sub-steps:
             <ul>
               <li>
@@ -2107,9 +2180,12 @@
         optionally  |onerror:ErrorListener| and |options:InteractionOptions|.
         It returns a {{Promise}} to signal success or failure.
         <p class="ednote">
-          This algorithm allows for only one active {{Subscription}} per <a>Event</a>. If a new
-          {{Subscription}} is made while an existing {{Subscription}} is active the runtime
-          will throw an {{NotAllowedError}}.
+          This algorithm allows for only one active {{Subscription}} per
+          <a>Event</a> and <a>subscription identifier</a> (i.e., per
+          combination of URI variables used to subscribe to the <a>Event</a>).
+          If a new {{Subscription}} is made with the same <a>Event</a> and the
+          same URI variables while an existing {{Subscription}} is active, the
+          runtime will throw an {{NotAllowedError}}.
         </p>
         The method MUST run the following steps:
         <ol>
@@ -2131,7 +2207,12 @@
             with a {{TypeError}} and stop.
           </li>
           <li>
-            If |thing|.{{ConsumedThing/[[activeSubscriptions]]}}[|eventName|] [=map/exists=], [=reject=] |promise| with a {{NotAllowedError}} and stop.
+            Let |subscriptionId| be the result of running the
+            <a>create a subscription identifier</a> steps given |eventName|
+            and |options|.
+          </li>
+          <li>
+            If |thing|.{{ConsumedThing/[[activeSubscriptions]]}}[|subscriptionId|] [=map/exists=], [=reject=] |promise| with a {{NotAllowedError}} and stop.
           </li>
           <li>
             Let |subscription| be a new {{Subscription}} object with its <a>internal slots</a>
@@ -2142,6 +2223,9 @@
               </li>
               <li>
                 Let |subscription|.{{Subscription/[[name]]}} be |eventName|.
+              </li>
+              <li>
+                Let |subscription|.{{Subscription/[[identifier]]}} be |subscriptionId|.
               </li>
               <li>
                 Let |subscription|.{{Subscription/[[interaction]]}} be |thing|. {{ConsumedThing/[[td]]}}.|events|[|eventName|].
@@ -2176,14 +2260,14 @@
             the <a>Protocol Bindings</a> and stop.
           </li>
           <li>
-            [=map/Set=] |eventName| to |thing|.{{ConsumedThing/[[activeSubscriptions]]}}[|eventName|] to |subscription|.
+            [=map/Set=] |thing|.{{ConsumedThing/[[activeSubscriptions]]}}[|subscriptionId|] to |subscription|.
           </li>
           <li>
              [=Resolve=] |promise|.
           </li>
           <li>
             Whenever the underlying platform detects a notification for the
-            <a>Event</a> |subscription| [=map/keyed=] on |eventName|, run the following sub-steps:
+            <a>Event</a> |subscription| [=map/keyed=] on |subscriptionId|, run the following sub-steps:
             <ol>
               <li>
                 Invoke |listener| given the result of running
@@ -2194,7 +2278,7 @@
           </li>
           <li>
             Whenever the underlying platform detects an error for
-            <a>Event</a> |subscription| [=map/keyed=] on |eventName|, run the following sub-steps:
+            <a>Event</a> |subscription| [=map/keyed=] on |subscriptionId|, run the following sub-steps:
             <ul>
               <li>
                 If the error is irrecoverable and stops the subscription, set
@@ -2326,6 +2410,18 @@
              <td>The <a>Property</a> or <a>Event</a> name.</td>
            </tr>
            <tr>
+             <td><dfn>[[\identifier]]</dfn></td>
+             <td>`null`</td>
+             <td>
+               The <a>subscription identifier</a> used as the key for this
+               {{Subscription}} in the {{ConsumedThing}}'s
+               {{ConsumedThing/[[activeObservations]]}} or
+               {{ConsumedThing/[[activeSubscriptions]]}} internal slot, taking
+               into account any URI variables used to create the
+               {{Subscription}}.
+             </td>
+           </tr>
+           <tr>
              <td><dfn>[[\interaction]]</dfn></td>
              <td>`null`</td>
              <td>
@@ -2399,10 +2495,10 @@
                   set <a href="#dom-subscription-active">active</a> to `false`.
                 </li>
                 <li>
-                  if {{Subscription/[[type]]}} is `"event"`, remove {{Subscription/[[name]]}} from {{Subscription/[[thing]]}}.{{ConsumedThing/[[activeSubscriptions]]}} .
+                  if {{Subscription/[[type]]}} is `"event"`, remove {{Subscription/[[identifier]]}} from {{Subscription/[[thing]]}}.{{ConsumedThing/[[activeSubscriptions]]}} .
                 </li>
                 <li>
-                  if {{Subscription/[[type]]}} is `"property"`, remove {{Subscription/[[name]]}} from {{Subscription/[[thing]]}}.{{ConsumedThing/[[activeObservations]]}} .
+                  if {{Subscription/[[type]]}} is `"property"`, remove {{Subscription/[[identifier]]}} from {{Subscription/[[thing]]}}.{{ConsumedThing/[[activeObservations]]}} .
                 </li>
                 <li>
                   [=Resolve=] |promise|.

--- a/index.html
+++ b/index.html
@@ -1919,73 +1919,15 @@
     </section>
 
     <section>
-      <h3>The <dfn data-lt="subscription identifier">create a subscription identifier</dfn> algorithm</h3>
-      <div>
-        A single <a>Property</a> or <a>Event</a> can be the target of several
-        active {{Subscription}}s at the same time, as long as they are made
-        with different URI variables. To distinguish between them, a
-        <a>subscription identifier</a> is used as the key of the
-        {{ConsumedThing/[[activeObservations]]}} and
-        {{ConsumedThing/[[activeSubscriptions]]}} internal slots instead of
-        plainly using the <a>Property</a> or <a>Event</a> name.
-        <p>
-          To <a>create a subscription identifier</a> given |name:string| and
-          |options:InteractionOptions|, run the following steps:
-        </p>
-        <ol>
-          <li>
-            Let |identifier| be |name|.
-          </li>
-          <li>
-            If |options|.|uriVariables| [=map/exists=], then:
-            <ol>
-              <li>
-                Let |keys| be the result of getting the keys of
-                |options|.|uriVariables|, sorted in ascending code point
-                order.
-              </li>
-              <li>
-                For each |key| in |keys|, set |identifier| to the
-                concatenation of |identifier|, `"&"`, |key|, `"="`, and the
-                result of running <a data-cite=
-                "infra#serialize-a-javascript-value-to-a-json-string">
-                serialize a JavaScript value to a JSON string</a> on
-                |options|.|uriVariables|[|key|].
-              </li>
-            </ol>
-          </li>
-          <li>
-            Return |identifier|.
-          </li>
-        </ol>
-        <p class="note">
-          <a>Protocol Bindings</a> MAY apply their own, more elaborate,
-          rationale for deciding whether two requests represent distinct
-          subscriptions. At the time of writing, [[!wot-thing-description11]]
-          only allows a client to distinguish requests to observe a
-          <a>Property</a> by their URI variables, and requests to subscribe to
-          an <a>Event</a> by their URI variables and subscription data;
-          implementations are therefore not expected to need anything more
-          elaborate than the algorithm above. Regardless of the algorithm
-          used, an implementation MUST NOT multiplex several {{Subscription}}s
-          (e.g., several listener functions) onto a single underlying
-          protocol-level subscription: every active {{Subscription}} is
-          expected to correspond to its own request to, and its own
-          notifications from, the underlying platform.
-        </p>
-      </div>
-    </section>
-
-    <section>
       <h3>The <dfn>observeProperty()</dfn> method</h3>
       <div>
         Makes a request for <a>Property</a> value change notifications.
         Takes as arguments |propertyName:string|, |listener:InteractionListener| and
         optionally |onerror:ErrorListener| and |options:InteractionOptions|.
         It returns a {{Promise}} that resolves on success and rejects on failure.
-        <p class="ednote">
+        <p class="note">
           This algorithm allows for only one active {{Subscription}} per
-          <a>Property</a> and <a>subscription identifier</a> (i.e., per
+          <a>Property</a> and <a>subscription identifier</a> (e.g., per
           combination of URI variables used to observe the <a>Property</a>).
           If a new {{Subscription}} is made with the same <a>Property</a> and
           the same URI variables while an existing {{Subscription}} is active,
@@ -2012,8 +1954,8 @@
           </li>
           <li>
             Let |observationId| be the result of running the
-            <a>create a subscription identifier</a> steps given |propertyName|
-            and |options|.
+            <a>create a subscription identifier</a> operation given
+            |propertyName| and |options|.
           </li>
           <li>
             If |thing|.{{ConsumedThing/[[activeObservations]]}}[|observationId|] [=map/exists=], [=reject=] |promise| with a {{NotAllowedError}} and stop.
@@ -2181,7 +2123,7 @@
         It returns a {{Promise}} to signal success or failure.
         <p class="ednote">
           This algorithm allows for only one active {{Subscription}} per
-          <a>Event</a> and <a>subscription identifier</a> (i.e., per
+          <a>Event</a> and <a>subscription identifier</a> (e.g., per
           combination of URI variables used to subscribe to the <a>Event</a>).
           If a new {{Subscription}} is made with the same <a>Event</a> and the
           same URI variables while an existing {{Subscription}} is active, the
@@ -2208,8 +2150,8 @@
           </li>
           <li>
             Let |subscriptionId| be the result of running the
-            <a>create a subscription identifier</a> steps given |eventName|
-            and |options|.
+            <a>create a subscription identifier</a> operation given
+            |eventName| and |options|.
           </li>
           <li>
             If |thing|.{{ConsumedThing/[[activeSubscriptions]]}}[|subscriptionId|] [=map/exists=], [=reject=] |promise| with a {{NotAllowedError}} and stop.
@@ -2563,6 +2505,46 @@
           </li>
         </ol>
       </section>
+    </section>
+
+    <section>
+      <h3><dfn data-lt="subscription identifier">Create a subscription identifier</dfn> operation</h3>
+      <div>
+        A single <a>Property</a> or <a>Event</a> can be the target of several
+        active {{Subscription}}s at the same time, as long as they can be
+        told apart. To distinguish between them, a <a>subscription
+          identifier</a> is used as the key of the
+        {{ConsumedThing/[[activeObservations]]}} and
+        {{ConsumedThing/[[activeSubscriptions]]}} internal slots instead of
+        plainly using the <a>Property</a> or <a>Event</a> name.
+        <p>
+          To <a>create a subscription identifier</a> given |name:string| and
+          |options:InteractionOptions|, return an [=implementation-defined=]
+          value that uniquely identifies the combination of |name| and
+          |options| among the {{ConsumedThing}}'s active {{Subscription}}s.
+          Two requests that yield the same identifier are considered to be
+          the same subscription; a request that yields a new identifier
+          MUST result in its own, separate request to the underlying
+          protocol binding, so that no two {{Subscription}}s ever share a single
+          protocol-level subscription.
+        </p>
+        <p class="note">
+          At the time of writing, [[!wot-thing-description11]] only lets a
+          client distinguish requests to observe a <a>Property</a> by their
+          URI variables, and requests to subscribe to an <a>Event</a> by
+          their URI variables and subscription data. Implementations are
+          therefore expected to derive the identifier from |name| together
+          with those values.
+        </p>
+        <p class="ednote" title="Implementation feedback">
+          This operation is intentionally left implementation-defined rather
+          than specified as a concrete algorithm. Feedback on whether a more
+          precise algorithm is needed, and on which parameters should
+          participate in the identifier, is welcome on the
+          <a href="https://github.com/w3c/wot-scripting-api/issues">GitHub
+            Issues</a> page.
+        </p>
+      </div>
     </section>
 
     <section>


### PR DESCRIPTION
Implements the fix proposed by @danielpeintner in #539: a Property/Event can now have multiple active Subscriptions at once, as long as they use different URI variables, instead of always being limited to one.

**Changes**

- New create a subscription identifier algorithm, keyed on name + sorted/serialized uriVariables.
observeProperty()/subscribeEvent() now key [[activeObservations]]/[[activeSubscriptions]] on this identifier instead of the bare property/event name.
- Added Subscription.[[identifier]] internal slot so stop() removes the right map entry.
- Updated ed-notes and slot descriptions to match.

**Open discussion point**: the added note says implementations "MUST NOT multiplex several Subscriptions onto a single underlying protocol-level subscription." That's normative (RFC2119) language sitting inside a class="note" block, which is conventionally non-normative. Should that requirement be pulled out into a numbered algorithm step (or its own normative paragraph) instead, leaving the note purely explanatory?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/relu91/wot-scripting-api/pull/603.html" title="Last updated on Jul 22, 2026, 3:25 PM UTC (b0c6ac5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/603/af77f9b...relu91:b0c6ac5.html" title="Last updated on Jul 22, 2026, 3:25 PM UTC (b0c6ac5)">Diff</a>