### PR TITLE
refactor: replace "MUST run" with "MUST execute"

### DIFF
--- a/index.html
+++ b/index.html
@@ -529,7 +529,7 @@
       };
     </pre>
     <div>
-      Belongs to the <a>WoT Consumer</a> conformance class. Expects an |td:ThingDescription| argument and returns a {{Promise}} that resolves with a {{ConsumedThing}} object that represents a client interface to operate with the <a>Thing</a>. The method MUST run the following steps:
+      Belongs to the <a>WoT Consumer</a> conformance class. Expects an |td:ThingDescription| argument and returns a {{Promise}} that resolves with a {{ConsumedThing}} object that represents a client interface to operate with the <a>Thing</a>. The method MUST execute the following steps:
       <ol>
         <li>
           Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
@@ -570,7 +570,7 @@
       Specifically, an <a>ExposedThingInit</a> value is a dictionary used for the initialization of an <a>ExposedThing</a> and
       it represents a <a>Partial TD</a> as described in the [[!wot-architecture11]]. As such, it has the same
       structure of a <a>Thing Description</a> but it may omit some information.
-      The method MUST run the following steps:
+      The method MUST execute the following steps:
       <ol>
         <li>
           Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
@@ -685,7 +685,7 @@
       };
     </pre>
     <div>
-      Belongs to the <a>WoT Discovery</a> conformance class. Starts the discovery process that will provide {{ThingDescription}} objects for <a>Thing Description</a>s that match an optional |filter:ThingFilter| argument of type {{ThingFilter}}. The method MUST run the following steps:
+      Belongs to the <a>WoT Discovery</a> conformance class. Starts the discovery process that will provide {{ThingDescription}} objects for <a>Thing Description</a>s that match an optional |filter:ThingFilter| argument of type {{ThingFilter}}. The method MUST execute the following steps:
       <ol>
         <li>
           Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
@@ -744,7 +744,7 @@
       };
     </pre>
     <div>
-      Belongs to the <a>WoT Discovery</a> conformance class. Starts the discovery process that given a <a>TD Directory</a> URL, will provide {{ThingDescription}} objects for <a>Thing Description</a>s that match an optional |filter:ThingFilter| argument of type {{ThingFilter}}. The method MUST run the following steps:
+      Belongs to the <a>WoT Discovery</a> conformance class. Starts the discovery process that given a <a>TD Directory</a> URL, will provide {{ThingDescription}} objects for <a>Thing Description</a>s that match an optional |filter:ThingFilter| argument of type {{ThingFilter}}. The method MUST execute the following steps:
       <ol>
         <li>
           Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
@@ -810,7 +810,7 @@
     <div>
       Belongs to the <a>WoT Discovery</a> conformance class.
       Requests a <a>Thing Description</a> from the given URL.
-      The method MUST run the following steps:
+      The method MUST execute the following steps:
       <ol>
         <li>
           Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
@@ -941,7 +941,7 @@
     <section><h3>The <dfn>value()</dfn> method</h3>
       Parses the data returned by the <a>WoT Interaction</a> and returns a
       value with the type described by the interaction <a>DataSchema</a>
-      if that exists, or by the `contentType` of the interaction <a>Form</a>. The method MUST run the following steps:
+      if that exists, or by the `contentType` of the interaction <a>Form</a>. The method MUST execute the following steps:
       <ol>
         <li>
           Return a {{Promise}} |promise:Promise| and execute the next steps
@@ -1008,7 +1008,7 @@
     </section>
 
     <section><h3>The <dfn>arrayBuffer()</dfn> method</h3>
-      When invoked, the `arrayBuffer()` method MUST run the following steps:
+      When invoked, the `arrayBuffer()` method MUST execute the following steps:
       <ol>
         <li>
           Return a {{Promise}} |promise:Promise| and execute the next steps
@@ -1320,7 +1320,7 @@
     </p>
 	
     <section><h3>The <dfn>query()</dfn> method</h3>
-      Reports the status of an <a>Action</a>, or rejects on error. The method MUST run the following steps:
+      Reports the status of an <a>Action</a>, or rejects on error. The method MUST execute the following steps:
       <ol>
         <li>
           Return a {{Promise}} |promise:Promise| and execute the next steps
@@ -1339,7 +1339,7 @@
       </ol>
     </section>
     <section><h3>The <dfn>cancel()</dfn> method</h3>
-      Cancels a running WoT <a>Action</a>, or rejects on error. The method MUST run the following steps:
+      Cancels a running WoT <a>Action</a>, or rejects on error. The method MUST execute the following steps:
       <ol>
         <li>
           Return a {{Promise}} |promise:Promise| and execute the next steps
@@ -1600,7 +1600,7 @@
         and optionally |options:InteractionOptions|.
         It returns a {{Promise}} that resolves with a <a>Property</a> value
         represented as an {{InteractionOutput}} object or rejects on error.
-        The method MUST run the following steps:
+        The method MUST execute the following steps:
         <ol>
           <li>
             Return a {{Promise}} |promise:Promise| and execute the next steps
@@ -1660,7 +1660,7 @@
         |options:InteractionOptions|.
         It returns a {{Promise}} that resolves with a {{PropertyReadMap}} object
         that maps keys from |propertyNames| to values returned by this algorithm.
-        The method MUST run the following steps:
+        The method MUST execute the following steps:
         <ol>
           <li>
             Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
@@ -1718,7 +1718,7 @@
         Reads all properties of the <a>Thing</a> with one request. Takes |options:InteractionOptions| as optional argument.
         It returns a {{Promise}} that resolves with a {{PropertyReadMap}} object that
         maps keys from <a>Property</a> names to values returned by this algorithm.
-        The method MUST run the following steps:
+        The method MUST execute the following steps:
         <ol>
           <li>
             Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
@@ -1785,7 +1785,7 @@
         Writes a single <a>Property</a>. Takes as arguments |propertyName:string|,
         |value:InteractionInput| and optionally |options:InteractionOptions|.
         It returns a {{Promise}} that resolves on success and rejects on failure.
-        The method MUST run the following steps:
+        The method MUST execute the following steps:
         <ol>
           <li>
             Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
@@ -1845,7 +1845,7 @@
         Takes as arguments |properties:object| - as an object with keys being
         <a>Property</a> names and values as <a>Property</a> values - and optionally
         |options:InteractionOptions|.
-        It returns a {{Promise}} that resolves on success and rejects on failure. The method MUST run the following steps:
+        It returns a {{Promise}} that resolves on success and rejects on failure. The method MUST execute the following steps:
         <ol>
           <li>
             Return a {{Promise}} |promise:Promise| and execute the next steps
@@ -1926,7 +1926,7 @@
           {{Subscription}} is made while an existing {{Subscription}} is active the runtime
           will throw an {{NotAllowedError}}.
         </p>
-        The method MUST run the following steps:
+        The method MUST execute the following steps:
         <ol>
           <li>
             Let |thing| be the reference of this {{ConsumedThing}} object.
@@ -2043,7 +2043,7 @@
         |params:InteractionInput| and optionally |options:InteractionOptions|.
         It returns a {{Promise}} that resolves with the result of the <a>Action</a>
         represented as an {{ActionInteractionOutput}} object, or rejects with an error.
-        The method MUST run the following steps:
+        The method MUST execute the following steps:
         <ol>
           <li>
             Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
@@ -2111,7 +2111,7 @@
           {{Subscription}} is made while an existing {{Subscription}} is active the runtime
           will throw an {{NotAllowedError}}.
         </p>
-        The method MUST run the following steps:
+        The method MUST execute the following steps:
         <ol>
           <li>
             Let |thing| be the reference of this {{ConsumedThing}} object.
@@ -2827,7 +2827,7 @@
       </p>
       <div>
         When the method is invoked given |name:string| and
-        |handler:PropertyReadHandler|, implementations MUST run the
+        |handler:PropertyReadHandler|, implementations MUST execute the
         following steps:
         <ol>
           <li>
@@ -2985,7 +2985,7 @@
       </p>
       <div>
         When the method is invoked given |name:string| and
-        |handler:PropertyReadHandler|, implementations MUST run the
+        |handler:PropertyReadHandler|, implementations MUST execute the
         following steps:
         <ol>
           <li>
@@ -3052,7 +3052,7 @@
       </p>
       <div>
         When the method is invoked given |name:string| and
-        |handler:PropertyReadHandler|, implementations MUST run the
+        |handler:PropertyReadHandler|, implementations MUST execute the
         following steps:
         <ol>
           <li>
@@ -3115,7 +3115,7 @@
         <a>Property</a> with the data provided by the |data| argument, or if not
         provided, it is obtained by the observe handler or the by
         read handler associated with that <a>Property</a>.
-        The method MUST run the following steps:
+        The method MUST execute the following steps:
         <ol>
           <li>Let |promise:Promise| be a new {{Promise}}.
           <li>
@@ -3234,7 +3234,7 @@
       </p>
       <div>
         When the method is invoked given |name:string| and
-        |handler:PropertyWriteHandler|, implementations MUST run the
+        |handler:PropertyWriteHandler|, implementations MUST execute the
         following steps:
         <ol>
           <li>
@@ -3255,7 +3255,7 @@
       <div>
         When a network request for writing a <a>Property</a> |name:string|
         with a new value |value:InteractionOutput| and |options:InteractionOptions|
-        is received, implementations MUST run the following
+        is received, implementations MUST execute the following
         <dfn>update property steps</dfn>, given |name|, |value|, |options|
         and |mode| set to `"single"`:
         <ol>
@@ -3628,7 +3628,7 @@
         Takes as arguments |name:string| denoting an <a>Event</a> name and
         optionally |data:InteractionInput|.
         Triggers emitting the <a>Event</a> with the optional data.
-        The method MUST run the following steps:
+        The method MUST execute the following steps:
         <ol>
           <li>
             Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
@@ -3654,7 +3654,7 @@
 
     <section> <h3>The <dfn>expose()</dfn> method</h3>
       <div>
-        Start serving external requests for the <a>Thing</a>, so that <a>WoT Interactions</a> using <a>Properties</a>, <a>Action</a>s and <a>Event</a>s will be possible. The method MUST run the following steps:
+        Start serving external requests for the <a>Thing</a>, so that <a>WoT Interactions</a> using <a>Properties</a>, <a>Action</a>s and <a>Event</a>s will be possible. The method MUST execute the following steps:
         <ol>
           <li>
             Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
@@ -3702,7 +3702,7 @@
 
     <section> <h3>The <dfn>destroy()</dfn> method</h3>
       <div>
-        Stop serving external requests for the <a>Thing</a> and destroy the object. Note that eventual unregistering should be done before invoking this method. The method MUST run the following steps:
+        Stop serving external requests for the <a>Thing</a> and destroy the object. Note that eventual unregistering should be done before invoking this method. The method MUST execute the following steps:
         <ol>
           <li>
             Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
@@ -4082,7 +4082,7 @@
     <section>
       <h3>The <dfn>next()</dfn> method of {{Symbol/asyncIterator}}</h3>
       <div>
-        Provides the next discovered {{ThingDescription}} object. The method MUST run the following steps:
+        Provides the next discovered {{ThingDescription}} object. The method MUST execute the following steps:
         <ol>
           <li>
             Return a {{Promise}} |promise:Promise| and execute the next steps [=in parallel=].
@@ -4104,7 +4104,7 @@
     <section>
       <h3>The <dfn>stop()</dfn> method</h3>
       <div>
-        Stops or suppresses the discovery process. It might not be supported by all discovery methods and endpoints, however, any further discovery results or errors will be discarded and the discovery is marked as done. The method MUST run the following steps:
+        Stops or suppresses the discovery process. It might not be supported by all discovery methods and endpoints, however, any further discovery results or errors will be discarded and the discovery is marked as done. The method MUST execute the following steps:
         <ol>
           <li>
             If invoking this method is not allowed for the current scripting context for security reasons, [= exception/throw =] a {{SecurityError}} and stop.


### PR DESCRIPTION
I checked all the replacements and "MUST execute" makes sense everyhwere to me. 

fixes https://github.com/w3c/wot-scripting-api/issues/596


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/danielpeintner/wot-scripting-api/pull/604.html" title="Last updated on Jul 27, 2026, 12:04 PM UTC (dfec6ad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-scripting-api/604/2486294...danielpeintner:dfec6ad.html" title="Last updated on Jul 27, 2026, 12:04 PM UTC (dfec6ad)">Diff</a>